### PR TITLE
feat: optional child operation links

### DIFF
--- a/link_bank_operation.js
+++ b/link_bank_operation.js
@@ -76,13 +76,13 @@ class BankOperationLinker {
       // of the possible labels (identifier)
       // If unsafe matching is enabled, also find all operations for which the entry could ba a part of
       for (let identifier of this.identifier) {
-        if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&
+        if (operation.label.toLowerCase().indexOf(identifier) >= 0 &&
           amountDelta <= this.amountDelta &&
           amountDelta <= minAmountDelta) {
           operationToLink = operation
           minAmountDelta = amountDelta
           break
-        } else if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&  // label must match
+        } else if (operation.label.toLowerCase().indexOf(identifier) >= 0 &&  // label must match
                  !operation.parent &&                                       // not a child operation itself
                  amountDelta > 0 &&                                         // op amount is smaller than entry amount
                  ((entry.isRefund && operation.amount > 0) ||               // if entry is refund, op is refund
@@ -133,7 +133,7 @@ class BankOperationLinker {
         BankOperation.attachBill(operation._id, link, (err, operation) => {
           if (err) this.log.error(err)
           else {
-            this.log.info(`Binary ${operation.bill} linked with operation: ${operation.title} - ${operation.amount}`)
+            this.log.info(`Binary ${operation.bill} linked with operation: ${operation.label} - ${operation.amount}`)
           }
           callback()
         })
@@ -154,7 +154,7 @@ class BankOperationLinker {
         BankOperation.createChildOperation(parentOperation, {
           amount: entry.amount,
           bill: link,
-          title: parentOperation.title + ' - ' + entry.subtype
+          label: parentOperation.label + ' - ' + entry.subtype
         }, callback)
       }
     })

--- a/link_bank_operation.js
+++ b/link_bank_operation.js
@@ -82,13 +82,12 @@ class BankOperationLinker {
           operationToLink = operation
           minAmountDelta = amountDelta
           break
-        }
-        else if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&  // label must match
+        } else if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&  // label must match
                  !operation.parent &&                                       // not a child operation itself
                  amountDelta > 0 &&                                         // op amount is smaller than entry amount
                  ((entry.isRefund && operation.amount > 0) ||               // if entry is refund, op is refund
                  (!entry.isRefund && operation.amount < 0)) &&              // if entry is expense, op is expense
-                 this.allowUnsafeLinks){
+                 this.allowUnsafeLinks) {
           candidateOperationsForLink.push(operation)
         }
       }
@@ -114,9 +113,9 @@ class BankOperationLinker {
       } else if (entries.length === 0) {
         callback(new Error('No matching entry found'))
       } else {
-        callback(null, entries[0]._id);
+        callback(null, entries[0]._id)
       }
-    });
+    })
   }
   linkOperation (operation, entry, callback) {
     this.getEntryId(entry, (err, entryId) => {
@@ -128,7 +127,7 @@ class BankOperationLinker {
       } else {
         let link = Bill.doctype + ':' + entryId
 
-        //if the operation and the entry are already linked, we can skip this step
+        // if the operation and the entry are already linked, we can skip this step
         if (operation.bill === link) return callback()
 
         BankOperation.attachBill(operation._id, link, (err, operation) => {
@@ -141,7 +140,7 @@ class BankOperationLinker {
       }
     })
   }
-  linkChildOperations (parentOperation, entry, callback){
+  linkChildOperations (parentOperation, entry, callback) {
     this.getEntryId(entry, (err, entryId) => {
       if (err) {
         // We ignore error, no need to make fail the import for that.

--- a/link_bank_operation.js
+++ b/link_bank_operation.js
@@ -23,6 +23,7 @@ class BankOperationLinker {
     this.dateDelta = options.dateDelta || 15
     this.minDateDelta = options.minDateDelta || this.dateDelta
     this.maxDateDelta = options.maxDateDelta || this.dateDelta
+    this.allowUnsafeLinks = options.allowUnsafeLinks || false
   }
   link (entries, callback) {
     async.eachSeries(entries, this.linkOperationIfExist.bind(this), callback)
@@ -52,6 +53,7 @@ class BankOperationLinker {
   // and the file ID as an extra attribute of the operation.
   linkRightOperation (operations, entry, callback) {
     let operationToLink = null
+    let candidateOperationsForLink = []
 
     let amount = Math.abs(parseFloat(entry.amount))
     // By default, an entry is an expense. If it is not, it should be
@@ -72,6 +74,7 @@ class BankOperationLinker {
       // Select the operation to link based on the minimal amount
       // difference to the expected one and if the label matches one
       // of the possible labels (identifier)
+      // If unsafe matching is enabled, also find all operations for which the entry could ba a part of
       for (let identifier of this.identifier) {
         if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&
           amountDelta <= this.amountDelta &&
@@ -80,37 +83,80 @@ class BankOperationLinker {
           minAmountDelta = amountDelta
           break
         }
+        else if (operation.title.toLowerCase().indexOf(identifier) >= 0 &&  // label must match
+                 !operation.parent &&                                       // not a child operation itself
+                 amountDelta > 0 &&                                         // op amount is smaller than entry amount
+                 ((entry.isRefund && operation.amount > 0) ||               // if entry is refund, op is refund
+                 (!entry.isRefund && operation.amount < 0)) &&              // if entry is expense, op is expense
+                 this.allowUnsafeLinks){
+          candidateOperationsForLink.push(operation)
+        }
       }
     }
 
     if (operationToLink !== null) {
       this.linkOperation(operationToLink, entry, callback)
+    } else if (candidateOperationsForLink.length > 0) {
+      // there may be several operations that fit this entry, but right now we don't have enough data to choose one. So we use the first one arbitrarily
+      let operation = candidateOperationsForLink[0]
+
+      this.linkChildOperations(operation, entry, callback)
     } else {
       callback()
     }
   }
-  linkOperation (operation, entry, callback) {
-    let date = new Date(entry.date)
-    let key = `${moment(date).format('YYYY-MM-DD')}T00:00:00.000Z`
+  getEntryId (entry, callback) {
+    let date = `${moment(new Date(entry.date)).format('YYYY-MM-DD')}T00:00:00.000Z`
 
-    Bill.findBy({date: key}, (err, entries) => {
-      // We ignore error, no need to make fail the import for that.
-      // We just log it.
+    Bill.findBy({date: date, amount: entry.amount}, (err, entries) => {
       if (err) {
+        callback(err)
+      } else if (entries.length === 0) {
+        callback(new Error('No matching entry found'))
+      } else {
+        callback(null, entries[0]._id);
+      }
+    });
+  }
+  linkOperation (operation, entry, callback) {
+    this.getEntryId(entry, (err, entryId) => {
+      if (err) {
+        // We ignore error, no need to make fail the import for that.
+        // We just log it.
         this.log.error(err)
         callback()
-      } else if (entries.length === 0) {
-        callback()
       } else {
-        let entry = entries[0]
+        let link = Bill.doctype + ':' + entryId
 
-        BankOperation.attachBill(operation._id, Bill.doctype + ':' + entry._id, (err, operation) => {
+        //if the operation and the entry are already linked, we can skip this step
+        if (operation.bill === link) return callback()
+
+        BankOperation.attachBill(operation._id, link, (err, operation) => {
           if (err) this.log.error(err)
           else {
             this.log.info(`Binary ${operation.bill} linked with operation: ${operation.title} - ${operation.amount}`)
           }
           callback()
         })
+      }
+    })
+  }
+  linkChildOperations (parentOperation, entry, callback){
+    this.getEntryId(entry, (err, entryId) => {
+      if (err) {
+        // We ignore error, no need to make fail the import for that.
+        // We just log it.
+        this.log.error(err)
+        callback()
+      } else {
+        let link = Bill.doctype + ':' + entryId
+
+        // Since the entry is only a subset of the operation, we create a child operation
+        BankOperation.createChildOperation(parentOperation, {
+          amount: entry.amount,
+          bill: link,
+          title: parentOperation.title + ' - ' + entry.subtype
+        }, callback)
       }
     })
   }

--- a/models/bankoperation.js
+++ b/models/bankoperation.js
@@ -35,5 +35,18 @@ module.exports = {
       .catch(err => {
         callback(err)
       })
+  },
+  createChildOperation (parentOperation, difference, callback) {
+    let attributes = Object.assign({}, parentOperation, difference)
+    attributes.parent = attributes._id
+    delete attributes._id
+    delete attributes._rev
+    delete attributes._type
+
+    cozy.data.create(DOCTYPE, attributes)
+      .then(() => callback(null))
+      .catch(err => {
+        callback(err)
+      })
   }
 }


### PR DESCRIPTION
This PR introduces a change that is not trivial, despite the amount of code being relatively small.

The idea is that sometimes, a bank operation actually represents more than one thing. For example, a 50€ refund may actually be two 25€ refunds, paid at once. Or a 100€ withdrawal at an ATM may be actually be a 40€ purchase, and then a 60€ purchase.

By enabling the  `allowUnsafeLinks` option, the program will try to create these sub-operations, based on the bills. This option is disabled by default, so it has no impact on existing konnectors.