### PR TITLE
feat: save reference to file id in the bill

### DIFF
--- a/models/file.js
+++ b/models/file.js
@@ -6,7 +6,7 @@ module.exports = {
   isPresent (fullPath, callback) {
     cozy.files.statByPath(fullPath)
     .then(file => {
-      callback(null, true)
+      callback(null, true, file)
     })
     .catch(() => callback(null, false))
   },

--- a/save_data_and_file.js
+++ b/save_data_and_file.js
@@ -29,7 +29,7 @@ module.exports = (log, model, options, tags) => {
       const entryLabel = entry.date.format('MMYYYY')
 
       function createFileAndSaveData (entry, entryLabel) {
-        File.isPresent(`${normalizedPath}/${fileName}`, (err, result) => {
+        File.isPresent(`${normalizedPath}/${fileName}`, (err, result, file) => {
           if (err) return callback(err)
           if (result === false) {
             const { pdfurl } = entry
@@ -42,18 +42,20 @@ module.exports = (log, model, options, tags) => {
                   onCreated, options.requestoptions)
             })
           } else {
-            onCreated()
+            onCreated(null, file)
           }
         })
       }
 
-      function onCreated (err) {
+      function onCreated (err, file) {
         if (err) {
           log.raw(err)
           log.info(`File for ${entryLabel} not created.`)
           return callback()
         } else {
           log.info(`File for ${entryLabel} created: ${fileName}`)
+          //add the file id to the entry
+          if (!entry.file) entry.file = file._id;
           return saveEntry(entry, entryLabel)
         }
       }


### PR DESCRIPTION
This change adds a `file` attribute in the data that is being saved, and it contains the `_id` of the matching file on the VFS.