### PR TITLE
feat: now the expected folderPath parameter is an id of folder and not a path

### DIFF
--- a/base_konnector.js
+++ b/base_konnector.js
@@ -41,6 +41,17 @@ module.exports = {
           process.exit(0)
         })
         .then(account => {
+          // get the folder path from the folder id and put it in cozyFields.folderPath
+          return new Promise((resolve, reject) => {
+            cozy.files.statById(cozyFields.folderPath, false)
+            .then(folder => {
+              cozyFields.folderPath = folder.attributes.path
+              resolve(account)
+            })
+            .catch(() => reject('NOT_EXISTING_DIRECTORY'))
+          })
+        })
+        .then(account => {
           const requiredFields = Object.assign({
             folderPath: cozyFields.folderPath
           }, account.auth, account.oauth)

--- a/cozy-client-js-stub.js
+++ b/cozy-client-js-stub.js
@@ -64,6 +64,10 @@ module.exports = {
         }
       })
     },
+    statById (idToCheck) {
+      // just return the / path for dev purpose
+      return Promise.resolve({attributes: {path: '/'}})
+    },
     create (file, options) {
       return new Promise((resolve, reject) => {
         log(`Creating new file ${options.name}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-konnector-libs",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "All the libs needed by a cozy v3 konnector",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This will adapt the konnectors to the real way of running it by the stack: with an id of folder as parameter.
Another part of this is done in the cozy-konnector-template and then in all the konnectors, one more time :-(