### PR TITLE
fix: avoid empty messages in error logs

### DIFF
--- a/base_konnector.js
+++ b/base_konnector.js
@@ -69,7 +69,7 @@ module.exports = {
           })
         })
         .catch(err => {
-          callback(err)
+          callback(err.message || err)
         })
       }
 

--- a/filter_existing.js
+++ b/filter_existing.js
@@ -19,7 +19,7 @@ module.exports = (log, model, suffix, vendor) => {
     // Get current entries
     return model.all(function (err, entryObjects) {
       let hash
-      if (err) { return next(err) }
+      if (err) { return next(err.message) }
       const entryHash = {}
 
       // Build an hash where key is the date and valie is the entry

--- a/save_data_and_file.js
+++ b/save_data_and_file.js
@@ -76,7 +76,7 @@ module.exports = (logger, model, options, tags) => {
         // moment.valueOf returns a timestamp that new Date() will parse
         return model.create(entry, function (err) {
           if (err) {
-            log('error', err)
+            log('error', err.message)
             log('error', `entry for ${entryLabel} not saved.`)
           } else {
             log('info', `entry for ${entryLabel} saved.`)
@@ -96,7 +96,7 @@ module.exports = (logger, model, options, tags) => {
       }
     }, function (err) {
       if (err) {
-        log('error', err)
+        log('error', err.message)
         return next()
       }
 
@@ -126,7 +126,7 @@ function checkForMissingFiles (options, callback) {
     // Check if the file is there.
     return File.isPresent(path, function (err, isPresent) {
       if (err) {
-        log('error', err)
+        log('error', err.message)
         return done()
       }
 
@@ -141,7 +141,7 @@ function checkForMissingFiles (options, callback) {
         return File.createNew(fileName, path, url, tags, function (err, file) {
           if (err) {
             log('error', 'An error occured while creating file')
-            log('error', err)
+            log('error', err.message)
           } else {
             done()
           }
@@ -150,7 +150,7 @@ function checkForMissingFiles (options, callback) {
     })
   }, err => {
     if (err) {
-      log('error', err)
+      log('error', err.message)
     }
     return callback()
   })

--- a/update_or_create.js
+++ b/update_or_create.js
@@ -27,7 +27,7 @@ module.exports = (logger, model, filter, options) =>
     data.created[modelName] = 0
 
     model.all((err, docs) => {
-      if (err) { return next(err) };
+      if (err) { return next(err.message) };
 
       async.eachSeries(news, (entry, cb) => {
         let toUpdate = docs.find(doc =>


### PR DESCRIPTION
When errors came from cozy-konnector-libs modules, it always was displayed as {"error", {}} in the standard output of the connector. Now we get the message from it.