### PR TITLE
CC-23 | Add a way to pass 2FA requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ konnectorLibs.models.file
 You can also find a working example with the Bouygues Telecom konnector: https://github.com/cozy/cozy-konnector-bouyguestelecom.git
 
 
+### About 2FA tokens
+
+The lib contains a way to wrap common errors. Those messages and methods are located under the `errors` namespace.
+
+If your konnector needs a 2FA token, we recommend that you call the `errors.requireTwoFactor` method in your code. This way, the stack and the Cozy-Collect app will be notified that the user needs to supply its token.
+
+The `requireTwoFactor` method allow you to pass a JS Object as argument. This object will be serialized when the 2FA notification will be passed to the Cozy-Collect app. When your user will supply its token, this object will be deserialized and passed as regular fields to your konnector. You'll so be able to continue the auth process. Common fields that can be passed are `SESSIONID` and `_csrf` tokens.
+
+
 ### Open a Pull-Request
 
 If you want to work on Cozy Konnector Libs and submit code modifications, feel free to open pull-requests! See the [contributing guide][contribute] for more information about how to properly open pull-requests.

--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const log = require('./logger')
+
+const MSG = {
+  TWOFACTOR: '2FA token requested'
+}
+
+function requireTwoFactor(extras = {}) {
+  const extrasStr = Buffer(JSON.stringify(extras), 'binary').toString('base64')
+  log('error', `${MSG.TWOFACTOR}||${extrasStr}`)
+}
+
+module.exports = {
+  MSG: MSG,
+  requireTwoFactor: requireTwoFactor
+}

--- a/errors.js
+++ b/errors.js
@@ -9,6 +9,7 @@ const MSG = {
 function requireTwoFactor(extras = {}) {
   const extrasStr = Buffer(JSON.stringify(extras), 'binary').toString('base64')
   log('error', `${MSG.TWOFACTOR}||${extrasStr}`)
+  return extrasStr
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   baseKonnector: require('./base_konnector'),
   cozyClient: require('./cozyclient'),
+  errors: require('./errors'),
   fetcher: require('./fetcher'),
   filterExisting: require('./filter_existing'),
   log: require('./logger'),


### PR DESCRIPTION
We need a way to inform the Cozy-Collect app that a konnector require a 2FA token (e.g. sent by SMS). This PR add a `errors` wrapper that exposes helpers. The first one is `requireTwoFactor`, that logs an `error` message that will be written to the stack's job. Its message is normalized (so Collect can use it to detect that the error is a 2FA requisite). A base64 serialized object can be append to the message string, so the konnector can pass a context (e.g. for _csrf and session token). Collect will then add them to its next request (when the user submit the 2FA token) so the konnector can continue its execution (same session, etc).

It's a little bit messy IMHO, but I can't find a better way to handle this use-case. 