### PR TITLE
Fix stub return values

### DIFF
--- a/cozy-client-js-stub.js
+++ b/cozy-client-js-stub.js
@@ -1,7 +1,13 @@
 const fs = require('fs')
 const path = require('path')
+const uuid = require('uuid/v5')
+const sha1 = require('uuid/lib/sha1')
+const bytesToUuid = require('uuid/lib/bytesToUuid')
+
 const log = require('debug')('cozy-client-js-stub')
+
 let fixture = {}
+
 const FIXTURE_PATH = path.resolve('data/fixture.json')
 if (fs.existsSync(FIXTURE_PATH)) {
   log(`Found ${FIXTURE_PATH} fixture file`)
@@ -12,11 +18,13 @@ module.exports = {
   data: {
     create (doctype, item) {
       log(item, `creating ${doctype}`)
-      return Promise.resolve(item)
+      const ns = bytesToUuid(sha1(doctype))
+      const _id = uuid(JSON.stringify(item), ns).replace(/-/gi, '')
+      return Promise.resolve(Object.assign({}, item, {_id}))
     },
     updateAttributes (doctype, id, attrs) {
       log(attrs, `updating ${id} in ${doctype}`)
-      return Promise.resolve({})
+      return Promise.resolve(Object.assign({}, attrs, {_id: id}))
     },
     defineIndex (doctype) {
       return Promise.resolve({doctype})

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "moment": "^2.18.1",
     "regenerator-runtime": "^0.10.5",
     "request": "^2.81.0",
+    "uuid": "^3.1.0",
     "ware": "^1.3.0"
   },
   "config": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,10 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
+uuid@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"


### PR DESCRIPTION
This PR fixes `create` and `updateAttributes` stubbed method, so running konnectors in `standalone` mode remains consistent with the stack actions.