### PR TITLE
Improve logging

### DIFF
--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -76,8 +76,8 @@ module.exports = class baseKonnector {
   saveAccountData (data, options) {
     options = options || {}
     options.merge = options.merge === undefined ? true : options.merge
-    const start = options.merge ? {...this.getAccountData()} : {}
-    const newData = {...start, ...data}
+    const start = options.merge ? Object.assign({}, this.getAccountData()) : {}
+    const newData = Object.assign({}, start, data)
     return cozy.data.updateAttributes('io.cozy.accounts', this.accountId, {data: newData})
       .then(account => {
         this._account = account

--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -2,6 +2,7 @@
 
 const cozy = require('./cozyclient')
 const log = require('./logger').namespace('BaseKonnector')
+const Secret = require('./Secret')
 
 module.exports = class baseKonnector {
   constructor (fetch) {
@@ -85,6 +86,6 @@ module.exports = class baseKonnector {
   }
 
   getAccountData () {
-    return this._account.data || {}
+    return new Secret(this._account.data || {})
   }
 }

--- a/libs/Secret.js
+++ b/libs/Secret.js
@@ -1,0 +1,10 @@
+const Secret = function (data) {
+  Object.assign(this, data)
+  return this
+}
+
+Secret.prototype.toString = function () {
+  throw new Error('Cannot convert Secret to string')
+}
+
+module.exports = Secret

--- a/libs/log-filters.js
+++ b/libs/log-filters.js
@@ -1,0 +1,16 @@
+const levels = {
+  debug: 0,
+  secret: 0,
+  info: 10,
+  warn: 20,
+  error: 30,
+  ok: 40
+}
+
+const filterLevel = function (level, type, message, label, namespace) {
+  return levels[type] >= levels[level]
+}
+
+module.exports = {
+  filterLevel
+}

--- a/libs/log-filters.js
+++ b/libs/log-filters.js
@@ -7,10 +7,20 @@ const levels = {
   ok: 40
 }
 
+const Secret = require('./Secret')
+
+const filterSecrets = function (level, type, message, label, namespace) {
+  if (type !== 'secret' && message instanceof Secret) {
+    const err = new Error()
+    throw new Error('You should log a secret with log.secret')
+  }
+}
+
 const filterLevel = function (level, type, message, label, namespace) {
   return levels[type] >= levels[level]
 }
 
 module.exports = {
+  filterSecrets,
   filterLevel
 }

--- a/libs/log-formats.js
+++ b/libs/log-formats.js
@@ -1,0 +1,46 @@
+const colors = require('colors')
+const util = require('util')
+util.inspect.defaultOptions.maxArrayLength = null
+util.inspect.defaultOptions.colors = true
+
+const type2color = {
+  debug: 'cyan',
+  warn: 'yellow',
+  info: 'blue',
+  error: 'red',
+  ok: 'green',
+  secret: 'red'
+}
+
+function prodFormat (type, message, label, namespace) {
+  // properly display error messages
+  if (message.stack) message = message.stack
+  if (message.toString) message = message.toString()
+
+  return JSON.stringify({ time: new Date(), type, message, label, namespace })
+}
+
+function devFormat (type, message, label, namespace) {
+  let formatmessage = message
+
+  if (typeof formatmessage !== 'string') {
+    formatmessage = util.inspect(formatmessage)
+  }
+
+  let formatlabel = label ? ` : "${label}" ` : ''
+  let formatnamespace = namespace ? colors.magenta(`${namespace}: `) : ''
+
+  let color = type2color[type]
+  let formattype = color ? colors[color](type) : type
+
+  return `${formatnamespace}${formattype}${formatlabel} : ${formatmessage}`
+}
+
+const env2formats = {
+  production: prodFormat,
+  development: devFormat,
+  standalone: devFormat,
+  test: devFormat
+}
+
+module.exports = { prodFormat, devFormat, env2formats }

--- a/libs/logger.js
+++ b/libs/logger.js
@@ -1,3 +1,5 @@
+const colors = require('colors')
+
 const util = require('util')
 util.inspect.defaultOptions.maxArrayLength = null
 util.inspect.defaultOptions.colors = true
@@ -10,6 +12,15 @@ const env2formats = {
   standalone: devFormat,
   test: devFormat
 }
+
+const type2color = {
+  debug: 'cyan',
+  warn: 'yellow',
+  info: 'blue',
+  error: 'red',
+  ok: 'green'
+}
+
 const format = env2formats[env]
 
 if (!format) console.error('Error while loading the logger')
@@ -42,23 +53,11 @@ function devFormat (type, message, label, namespace) {
     formatmessage = util.inspect(formatmessage)
   }
 
-  let formatlabel = ` : "${label}" `
-  if (label === undefined) formatlabel = ``
+  let formatlabel = label ? ` : "${label}" ` : ''
+  let formatnamespace = namespace ? colors.purple(`${namespace}: `) : ''
 
-  let formatnamespace = `\u001b[35m${namespace}: \u001b[0m`
-  if (namespace === undefined) formatnamespace = ``
+  let color = type2color[type]
+  let formattype = color ? colors[color](type) : type
 
-  const type2color = {
-    debug: 6,   // cyan
-    warning: 3, // yellow
-    info: 4,    // blue
-    error: 1,   // red
-    ok: 2       // green
-  }
-
-  let formattype = type
-  if (type2color[type]) {
-    formattype = `\u001b[3${type2color[type]}m${type}\u001b[0m`
-  }
   return `${formatnamespace}${formattype}${formatlabel} : ${formatmessage}`
 }

--- a/libs/logger.js
+++ b/libs/logger.js
@@ -1,11 +1,12 @@
 const { env2formats } = require('./log-formats')
-const { filterLevel } = require('./log-filters')
+const { filterLevel, filterSecrets } = require('./log-filters')
 
-const { DEBUG, NODE_ENV } = process.env
+const { DEBUG, NODE_ENV, LOG_LEVEL } = process.env
 const env = (env2formats[NODE_ENV] && NODE_ENV) || 'production'
-let level = DEBUG && DEBUG.length ? 'debug' : 'info'
+
+let level = LOG_LEVEL || (DEBUG && DEBUG.length ? 'debug' : 'info')
 const format = env2formats[env]
-const filters = [filterLevel]
+const filters = [filterLevel, filterSecrets]
 
 const filterOut = function (level, type, message, label, namespace) {
   for (const filter of filters) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bluebird-retry": "^0.11.0",
     "btoa": "^1.1.2",
     "cheerio": "^1.0.0-rc.2",
+    "colors": "^1.1.2",
     "core-js": "^2.4.1",
     "cozy-client-js": "^0.3.17",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,10 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colors@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"


### PR DESCRIPTION
I added `Secret`s object that you must log via log('secret'). The log level of secret is the same as debug which make it difficult to leak credential data in production.