### PR TITLE
fix: remove object spread in BaseKonnector

### DIFF
--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -75,8 +75,8 @@ module.exports = class baseKonnector {
   saveAccountData (data, options) {
     options = options || {}
     options.merge = options.merge === undefined ? true : options.merge
-    const start = options.merge ? {...this.getAccountData()} : {}
-    const newData = {...start, ...data}
+    const start = options.merge ? Object.assign({}, this.getAccountData()) : {}
+    const newData = Object.assign({}, start, data)
     return cozy.data.updateAttributes('io.cozy.accounts', this.accountId, {data: newData})
       .then(account => {
         this._account = account


### PR DESCRIPTION
This way, new connector developpers are not forced to use babel.

When we take the time to package cozy-konnector-libs with babel we will be able to use syntaxes not deployed with node 6.

At the moment, we take the risk loose new connectors contributors with one more way to fail.