### PR TITLE
✨ feat: ability to pass options to cozy-konnector-dev

### DIFF
--- a/commands/dev.js
+++ b/commands/dev.js
@@ -1,14 +1,23 @@
-'use strict'
-
 process.env.NODE_ENV = 'development'
 if (!process.env.DEBUG) process.env.DEBUG = '*'
 
+const program = require('commander')
+const authenticate = require('../helpers/cozy-authenticate')
+const initDevAccount = require('../helpers/init-dev-account')
 const config = require('../helpers/init-konnector-config')()
+const path = require('path')
+
 process.env.COZY_URL = config.COZY_URL
 
 let useFolder = false
 
-require('../helpers/cozy-authenticate')()
+program
+  .usage('[options] <file>')
+  .option('-t, --token [value]', 'Token file location (will be created if does not exist)', abspath)
+  .option('-m, --manifest [value]', 'Manifest file for permissions (manifest.webapp or manifest.konnector)', abspath)
+  .parse(process.argv)
+
+authenticate({ tokenPath: program.token, manifestPath: program.manifest })
 .then(result => {
   const credentials = result.creds
   const scopes = result.scopes
@@ -17,16 +26,21 @@ require('../helpers/cozy-authenticate')()
   // check if the token is valid
   process.env.COZY_CREDENTIALS = JSON.stringify(credentials)
 })
-.then(() => require('../helpers/init-dev-account')())
+.then(() => initDevAccount())
 .then((accountId) => {
   process.env.COZY_FIELDS = JSON.stringify({
     account: accountId,
     folder_to_save: useFolder ? 'io.cozy.files.root-dir' : ''
   })
-  const filename = process.argv[2] || 'index.js'
-  return require(require('path').resolve(filename))
+  const filename = program.args[0] || 'index.js'
+  const filepath = path.resolve(filename)
+  return require(filepath)
 })
 .catch(err => {
   console.log(err, 'unexpected error')
   setImmediate(() => process.exit(1))
 })
+
+function abspath (p) {
+  if (p) { return path.resolve(p) }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,14 +44,22 @@ and run:
 npm run dev
 ```
 
-This command will register your konnector as an OAuth application to the cozy-stack. By default,
+This command will register your konnector as an OAuth application to the cozy-stack and then set the `COZY_CREDENTIALS` and `COZY_FIELDS` environment variable. By default,
 the cozy-stack is supposed to be located in http://cozy.tools:8080. If this is not your case, just
 update the COZY_URL field in [./konnector-dev-config.json].
 
 After that, your konnector is running but should not work since you did not specify any credentials to
-the target service. You can do this also in [./konnector-dev-config.json] in the "fields" section
+the target service. You can do this also in [./konnector-dev-config.json] in the "fields" section.
 
 The files are saved in the root directory of your cozy by default.
 
-As for standalone command, it is possible to add an argument to this command which tells which file to run. Default is
-./index.js
+##### Arguments
+
+```
+$ cozy-konnector-dev <file> [-t token.json] [-m manifest.webapp]
+```
+
+As for the `standalone` command, you can specify which file to run. Default is `./index.js`.
+
+- `-t`, `--token` : Specify where the token should be saved
+- `-m`, `--manifest` : Specify the manifest.path that should be used for the permissions

--- a/helpers/cozy-authenticate.js
+++ b/helpers/cozy-authenticate.js
@@ -7,14 +7,11 @@ const log = require('../libs/logger').namespace('cozy-authenticate')
 const {Client, MemoryStorage} = require('cozy-client-js')
 const manifest = require('./manifest')
 
-const manifestPath = path.resolve('manifest.konnector')
+const DEFAULT_MANIFEST_PATH = path.resolve('manifest.konnector')
+const DEFAULT_TOKEN_PATH = path.resolve('.token.json')
 
 const cozyURL = process.env.COZY_URL ? process.env.COZY_URL : 'http://cozy.tools:8080'
 log('debug', cozyURL, 'COZY_URL')
-
-const scopes = manifest.getScopes(manifestPath)
-
-const tokenPath = path.resolve('.token.json')
 
 // check if we have a token file
 // if any return a promise with the credentials
@@ -44,7 +41,8 @@ function onRegistered (client, url) {
   })
 }
 
-function authenticate () {
+function authenticate ({ manifestPath = DEFAULT_MANIFEST_PATH, tokenPath = DEFAULT_TOKEN_PATH }) {
+  const scopes = manifest.getScopes(manifestPath)
   if (fs.existsSync(tokenPath)) {
     log('debug', 'token file already present')
     return Promise.resolve({creds: JSON.parse(fs.readFileSync(tokenPath)), scopes})

--- a/helpers/init-dev-account.js
+++ b/helpers/init-dev-account.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const cozy = require('../libs/cozyclient')
 const fs = require('fs')
 const path = require('path')
 const log = require('../libs/logger').namespace('init-dev-account')
@@ -12,6 +11,8 @@ module.exports = function () {
 }
 
 function ensureAccount () {
+  const cozy = require('../libs/cozyclient')
+
   return getAccountId()
     .then(id => {
       log('debug', 'Found .account file')
@@ -33,6 +34,7 @@ function getAccountId () {
 }
 
 function createAccount () {
+  const cozy = require('../libs/cozyclient')
   log('info', 'Creating a new dev account')
   return cozy.data.create('io.cozy.accounts', {
     name: 'dev_account',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "btoa": "^1.1.2",
     "cheerio": "^1.0.0-rc.2",
     "colors": "^1.1.2",
+    "commander": "^2.12.2",
     "core-js": "^2.4.1",
     "cozy-client-js": "^0.3.17",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,10 @@ command-line-usage@^4.0.0:
     table-layout "^0.4.1"
     typical "^2.6.1"
 
+commander@^2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 common-sequence@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/common-sequence/-/common-sequence-1.0.2.tgz#30e07f3f8f6f7f9b3dee854f20b2d39eee086de8"


### PR DESCRIPTION
Ability to configure manifest path and token path from command line.

This way I can launch the `notifications.js` service of Bank with cozy-konnector-dev.

```
bank $ yarn run cozy-konnector-dev build/notifications.json -m manifest.webapp -t /tmp/token.json
```