### PR TITLE
feat: deactivate json header if cheerio is activated

### DIFF
--- a/libs/request.js
+++ b/libs/request.js
@@ -49,6 +49,8 @@ module.exports = function (options = {}) {
 
   options = Object.assign(defaultOptions, options)
 
+  if (options.cheerio === true && !options.json) options.json = false
+
   if (options.debug) {
     // This avoids an error message comming from request-debug
     // see https://github.com/request/request-debug/blob/0.2.0/index.js#L15


### PR DESCRIPTION
json header can cause some trouble on some vendors and we know we do not want json when doing scrapping