### PR TITLE
fix: yarn dev command did not take url in konnect-dev-config.json into account

### DIFF
--- a/commands/dev.js
+++ b/commands/dev.js
@@ -2,12 +2,12 @@ process.env.NODE_ENV = 'development'
 if (!process.env.DEBUG) process.env.DEBUG = '*'
 
 const program = require('commander')
+const config = require('../helpers/init-konnector-config')()
+process.env.COZY_URL = config.COZY_URL
 const authenticate = require('../helpers/cozy-authenticate')
 const initDevAccount = require('../helpers/init-dev-account')
-const config = require('../helpers/init-konnector-config')()
 const path = require('path')
 
-process.env.COZY_URL = config.COZY_URL
 
 let useFolder = false
 


### PR DESCRIPTION
The cocy-authenticate command was run before the COZY_URL env variable would be defined