### PR TITLE
Adding sentry

### DIFF
--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -1,0 +1,56 @@
+const log = require('../libs/logger')
+const Raven = require('raven')
+
+const SENTRY_DSN = process.env.SENTRY_DSN
+
+const afterFatalError = function (err, sendErr, eventId) {
+  if (!sendErr) {
+    log('info', 'Successfully sent fatal error with eventId ' + eventId + ' to Sentry');
+  }
+  process.exit(1);
+}
+
+const afterCaptureException = function (sendErr, eventId) {
+  if (!sendErr) {
+    log('info', 'Successfully sent exception with eventId ' + eventId + ' to Sentry');
+  }
+  process.exit(1)
+}
+
+const setupSentry = function () {
+  try {
+    log('info', 'process.env.SENTRY_DSN found, setting up Raven')
+    const release = typeof GIT_SHA !== 'undefined' ? GIT_SHA : 'dev'
+    Raven.config(SENTRY_DSN, { release }).install(afterFatalError)
+    log('info', 'Raven configured !')
+  } catch (e) {
+    log('warn', 'Could not load Raven, errors will not be sent to Sentry')
+    log('warn', e)
+  }
+}
+
+module.exports.captureExceptionAndDie = function (err) {
+  log('info', 'Capture exception and die')
+  if (!Raven) {
+    process.exit(1)
+  } else {
+    try {
+      log('info', 'Sending exception to Sentry')
+      Raven.captureException(err, afterCaptureException)
+    } catch (e) {
+      log('warn', 'Could not send error to Sentry, exiting...')
+      log('warn', e)
+      process.exit(1)
+    }
+  }
+}
+
+module.exports.wrapIfSentrySetUp = function (obj, method) {
+  if (SENTRY_DSN) {
+    obj[method] = Raven.wrap(obj[method])
+  }
+}
+
+if (SENTRY_DSN) {
+  setupSentry()
+}

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -21,7 +21,8 @@ const setupSentry = function () {
   try {
     log('info', 'process.env.SENTRY_DSN found, setting up Raven')
     const release = typeof GIT_SHA !== 'undefined' ? GIT_SHA : 'dev'
-    Raven.config(SENTRY_DSN, { release }).install(afterFatalError)
+    const environment = process.env.NODE_ENV
+    Raven.config(SENTRY_DSN, { release, environment }).install(afterFatalError)
     log('info', 'Raven configured !')
   } catch (e) {
     log('warn', 'Could not load Raven, errors will not be sent to Sentry')

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -60,6 +60,7 @@ module.exports.captureExceptionAndDie = function (err) {
     } catch (e) {
       log('warn', 'Could not send error to Sentry, exiting...')
       log('warn', e)
+      log('warn', err)
       process.exit(1)
     }
   }

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -4,16 +4,19 @@ const getDomain = require('./cozy-domain')
 
 let isRavenConfigured = false
 
+const ENV_DEV = 'development'
+const ENV_SELF = 'selfhost'
+const ENV_PROD = 'production'
 
 const domainToEnv = {
-  'cozy.tools': 'development',
-  'cozy.works': 'development',
-  'cozy.rocks': 'production',
-  'mycozy.cloud': 'production'
+  'cozy.tools': ENV_DEV,
+  'cozy.works': ENV_DEV,
+  'cozy.rocks': ENV_PROD,
+  'mycozy.cloud': ENV_PROD
 }
 
 const getEnvironmentFromDomain = domain => {
-  return domainToEnv[domain] || 'selfhost'
+  return domainToEnv[domain] || ENV_SELF
 }
 
 // Available in Projet > Settings > Client Keys

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -2,7 +2,8 @@ const log = require('../libs/logger')
 const Raven = require('raven')
 const getDomain = require('./cozy-domain')
 
-let ravenOK = false
+let isRavenConfigured = false
+
 
 const domainToEnv = {
   'cozy.tools': 'development',
@@ -41,7 +42,7 @@ const setupSentry = function () {
     const environment = getEnvironmentFromDomain(domain)
     Raven.config(SENTRY_DSN, { release, environment }).install(afterFatalError)
     Raven.mergeContext({ extra: {domain} })
-    ravenOK = true
+    isRavenConfigured = true
     log('info', 'Raven configured !')
   } catch (e) {
     log('warn', 'Could not load Raven, errors will not be sent to Sentry')
@@ -51,7 +52,7 @@ const setupSentry = function () {
 
 module.exports.captureExceptionAndDie = function (err) {
   log('info', 'Capture exception and die')
-  if (!ravenOK) {
+  if (!isRavenConfigured) {
     process.exit(1)
   } else {
     try {

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -2,6 +2,8 @@ const log = require('../libs/logger')
 const Raven = require('raven')
 const getDomain = require('./cozy-domain')
 
+let ravenOK = false
+
 const domainToEnv = {
   'cozy.tools': 'development',
   'cozy.works': 'development',
@@ -39,6 +41,7 @@ const setupSentry = function () {
     const environment = getEnvironmentFromDomain(domain)
     Raven.config(SENTRY_DSN, { release, environment }).install(afterFatalError)
     Raven.mergeContext({ extra: {domain} })
+    ravenOK = true
     log('info', 'Raven configured !')
   } catch (e) {
     log('warn', 'Could not load Raven, errors will not be sent to Sentry')
@@ -48,7 +51,7 @@ const setupSentry = function () {
 
 module.exports.captureExceptionAndDie = function (err) {
   log('info', 'Capture exception and die')
-  if (!Raven) {
+  if (!ravenOK) {
     process.exit(1)
   } else {
     try {

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -44,7 +44,7 @@ const setupSentry = function () {
     const domain = getDomain()
     const environment = getEnvironmentFromDomain(domain)
     Raven.config(SENTRY_DSN, { release, environment }).install(afterFatalError)
-    Raven.mergeContext({ extra: {domain} })
+    Raven.mergeContext({ tags: {domain} })
     isRavenConfigured = true
     log('info', 'Raven configured !')
   } catch (e) {

--- a/helpers/sentry.js
+++ b/helpers/sentry.js
@@ -1,6 +1,8 @@
 const log = require('../libs/logger')
 const Raven = require('raven')
 
+// Available in Projet > Settings > Client Keys
+// Example : https://5f94cb7772deadbeef123456:39e4e34fdeadbeef123456a9ae31caba74c@sentry.cozycloud.cc/12
 const SENTRY_DSN = process.env.SENTRY_DSN
 
 const afterFatalError = function (err, sendErr, eventId) {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   updateOrCreate: require('./libs/updateOrCreate'),
   request: deprecate(requestFactory, 'Use requestFactory instead of request. It will be removed in cozy-konnector-libs@4'),
   requestFactory,
-  retry: require('bluebird-retry')
+  retry: require('bluebird-retry'),
+  wrapIfSentrySetUp: require('./helpers/sentry').wrapIfSentrySetUp
 }
 
 function deprecate (wrapped, message) {

--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -31,7 +31,7 @@ const errors = require('../helpers/errors')
  * this.terminate('LOGIN_FAILED')
  * ```
  */
-class baseKonnector {
+class BaseKonnector {
   /**
    * Constructor
    *
@@ -178,3 +178,5 @@ class baseKonnector {
 }
 
 module.exports = baseKonnector
+
+module.exports = BaseKonnector

--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -4,6 +4,10 @@ const cozy = require('./cozyclient')
 const log = require('./logger').namespace('BaseKonnector')
 const Secret = require('./Secret')
 const errors = require('../helpers/errors')
+const {
+  wrapIfSentrySetUp,
+  captureExceptionAndDie
+} = require('../helpers/sentry')
 
 /**
  * @class
@@ -161,22 +165,13 @@ class BaseKonnector {
    *
    * @param  {string} message - The error code to be saved as connector result see [docs/ERROR_CODES.md]
    */
-  terminate (message) {
-    // Encapsulating in a Promise allows to prevent then() calls before
-    // process.exit is actually called.
-    return new Promise(() => {
-      // The error log is also sent to be compatible with older versions of the cozy stack
-      // For version of the stack older than 18bcbd5865a46026de6f794f661d83d5d87a3dbf
-      log('error', message)
-      log('critical', message)
-      // Allow asynchronous calls to end, for example, previous log calls.
-      // To breack promise chaining and avoid then() calls to be made,
-      // The call is encapsulated in a promise, see above.
-      setImmediate(() => process.exit(1))
-    })
+  terminate (err) {
+    log('error', err.message || err)
+    log('critical', err.message || err)
+    captureExceptionAndDie(err)
   }
 }
 
-module.exports = baseKonnector
+wrapIfSentrySetUp(BaseKonnector.prototype, 'run')
 
 module.exports = BaseKonnector

--- a/libs/logger.js
+++ b/libs/logger.js
@@ -49,9 +49,6 @@ function log (type, message, label, namespace) {
     return
   }
   console.log(format(type, message, label, namespace))
-
-  // Try to stop the connector after current running io before the stack
-  if (type === 'critical') setImmediate(() => process.exit(1))
 }
 
 log.addFilter = function (filter) {


### PR DESCRIPTION
If process.env.SENTRY_DSN is set, we configure Raven. We expect the stack in the future to give the SENTRY_DSN to the konnectors. This configuration could be for example set in the the konnector manifest.

The `run` method is wrapped is a Raven context and the `terminate` method captures the exception.