### PR TITLE
🐝 fix: exit with the right status codes

### DIFF
--- a/libs/error.js
+++ b/libs/error.js
@@ -4,10 +4,13 @@ const log = require('./logger').namespace('Error Interception')
 process.on('uncaughtException', err => {
   console.error(err, 'uncaught exception')
   log('critical', err.message, 'uncaught exception')
+  process.exit(1)
 })
 process.on('SIGTERM', () => {
   log('critical', 'The konnector got a SIGTERM')
+  process.exit(128 + 15)
 })
 process.on('SIGINT', () => {
   log('critical', 'The konnector got a SIGINT')
+  process.exit(128 + 2)
 })


### PR DESCRIPTION
Exit with the right status codes when processing 

* sigterm
* sigint
* uncaught error