### PR TITLE
Handle group amount

### DIFF
--- a/libs/addData.js
+++ b/libs/addData.js
@@ -4,18 +4,19 @@
  * @module addData
  */
 const bluebird = require('bluebird')
+const omit = require('lodash/omit')
 const log = require('./logger').namespace('addData')
 
 module.exports = (entries, doctype) => {
   const cozy = require('./cozyclient')
-  return bluebird.mapSeries(entries, entry => {
+  return bluebird.mapSeries(entries, async entry => {
     log('debug', entry, 'Adding this entry')
-    return cozy.data.create(doctype, entry)
-    .then(dbEntry => {
-      // also update the original entry _id to allow saveBills' linkBankOperation entries to have
-      // an id
-      entry._id = dbEntry._id
-      return dbEntry
-    })
+    const dbEntry = await (entry._id
+      ? cozy.data.update(doctype, entry, omit(entry, '_rev'))
+      : cozy.data.create(doctype, entry))
+    // Also update the original entry _id to allow saveBills'
+    // linkBankOperation entries to have an id
+    entry._id = dbEntry._id
+    return dbEntry
   })
 }

--- a/libs/hydrateAndFilter.js
+++ b/libs/hydrateAndFilter.js
@@ -13,6 +13,7 @@
 
 const bluebird = require('bluebird')
 const log = require('./logger').namespace('hydrateAndFilter')
+const get = require('lodash/get')
 const uniqBy = require('lodash/uniqBy')
 
 /**
@@ -49,7 +50,7 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
 
   const createHash = item => {
     return keys.map(key => {
-      let result = item[key]
+      let result = get(item, key)
       if (key === 'date') result = new Date(result)
       return result
     }).join('####')
@@ -57,7 +58,6 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
 
   const getIndex = () => {
     const index = options.index ? options.index : cozy.data.defineIndex(doctype, keys)
-
     return index
   }
 

--- a/libs/hydrateAndFilter.js
+++ b/libs/hydrateAndFilter.js
@@ -1,16 +1,40 @@
 /**
  * Used not to duplicate data.
  *
- * * `options` :
- *    - `keys` : List of keys used to check that two items are the same. By default it is set to `['id']'.
- *    - `index` : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
- *    - `selector` : Mango request to get records. Default is built from the keys `{selector: {_id: {"$gt": null}}}` to get all the records.
+ * `options`:
+ * - `index` : As returned by `cozy.data.defineIndex`. Default corresponds
+ *   to all documents of the selected doctype
+ * - `selector` : Mango query. Default one is `{selector: {_id: {"$gt": null}}}` to
+ *    get all the records.
+ * - `keys` : List of keys used to check that two items are the same. Default is `['_id']`
  *
  * @module filterData
  */
 
 const bluebird = require('bluebird')
 const log = require('./logger').namespace('hydrateAndFilter')
+const uniqBy = require('lodash/uniqBy')
+
+/**
+ * Since we can use methods or basic functions for
+ * `shouldSave` and `shouldUpdate` we pass the
+ * appropriate `this` and `arguments`.
+ *
+ * If `funcOrMethod` is a method, it will be called
+ * with args[0] as `this` and the rest as `arguments`
+ * Otherwise, `this` will be null and `args` will be passed
+ * as `arguments`.
+ */
+const suitableCall = (funcOrMethod, ...args) => {
+  const arity = funcOrMethod.length
+  if (arity < args.length) {
+    // must be a method
+    return funcOrMethod.apply(args[0], args.slice(1))
+  } else {
+    // must be a function
+    return funcOrMethod.apply(null, args)
+  }
+}
 
 const hydrateAndFilter = (entries, doctype, options = {}) => {
   const cozy = require('./cozyclient')
@@ -18,12 +42,6 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
   log('debug', String(entries.length), 'Number of items before hydrateAndFilter')
   if (!doctype) return Promise.reject(new Error(`Doctype is mandatory to filter the connector data.`))
 
-  // expected options:
-  //  - index : this is return value which returned by cozy.data.defineIndex, the default will
-  //  correspond to all document of the selected doctype
-  //  - selector : this the mango request : default one will be {selector: {_id: {"$gt": null}}} to
-  //  get all the records
-  //  - keys : this is the list of keys used to check that two items are the same
   const keys = options.keys ? options.keys : ['_id']
   const store = {}
 
@@ -62,7 +80,7 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
     })
   }
 
-  // We add _id to `entries` that we find in the database.
+  // We add `_id` to `entries` that we find in the database.
   // This is useful when linking with bank operations (a bill
   // can already be in the database but not already matched
   // to an operation) since the linking operation need the _id
@@ -72,16 +90,28 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
       const key = createHash(entry)
       if (store[key]) {
         entry._id = store[key]._id
+        entry._rev = store[key]._rev
       }
     })
     return entries
   }
 
-  const filterEntries = store => () => {
-    // filter out existing items
-    return bluebird.filter(entries, entry => {
-      return !store[createHash(entry)]
-    })
+  const defaultShouldSave = () => true
+  const defaultShouldUpdate = existing => false
+
+  const filterEntries = store => async () => {
+    // Filter out items according to shouldSave / shouldUpdate.
+    // Both can be passed as option or can be part of the entry.
+    return uniqBy(await bluebird.filter(entries, entry => {
+      const shouldSave = entry.shouldSave || options.shouldSave || defaultShouldSave
+      const shouldUpdate = entry.shouldUpdate || options.shouldUpdate || defaultShouldUpdate
+      const existing = store[createHash(entry)]
+      if (existing) {
+        return suitableCall(shouldUpdate, entry, existing)
+      } else {
+        return suitableCall(shouldSave, entry)
+      }
+    }), entry => (entry && entry._id) || entry)
   }
 
   const formatOutput = entries => {

--- a/libs/hydrateAndFilter.js
+++ b/libs/hydrateAndFilter.js
@@ -116,8 +116,7 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
 
   const formatOutput = entries => {
     log('debug', String(entries.length), 'Number of items after hydrateAndFilter')
-    // filter out wrong entries
-    return entries.filter(entry => entry)
+    return entries
   }
 
   return getIndex()
@@ -125,6 +124,7 @@ const hydrateAndFilter = (entries, doctype, options = {}) => {
     .then(populateStore(store))
     .then(hydrateExistingEntries(store))
     .then(filterEntries(store))
+    .then(entries => entries.filter(Boolean)) // Filter out wrong entries
     .then(formatOutput)
 }
 

--- a/libs/hydrateAndFilter.spec.js
+++ b/libs/hydrateAndFilter.spec.js
@@ -1,0 +1,98 @@
+jest.mock('./cozyclient', () => ({
+  data: {
+    query: jest.fn(),
+    defineIndex: jest.fn()
+  }
+}))
+
+const cozy = require('./cozyclient')
+const hydrateAndFilter = require('./hydrateAndFilter')
+
+class Document {
+  constructor (attributes) {
+    if (this.validate) {
+      this.validate(attributes)
+    }
+    Object.assign(this, attributes, {
+      metadata: {
+        version: this.constructor.version
+      }
+    })
+  }
+
+  toJSON () {
+    return this
+  }
+}
+
+const asyncResolve = data => (
+  new Promise(resolve => setImmediate(() => resolve(data)))
+)
+
+const basicEntries = [
+  {name: 'Marge'},
+  {name: 'Homer'},
+  {name: 'Bart'},
+  {name: 'Lisa'},
+  {name: 'Maggie'},
+]
+
+const copy = data => JSON.parse(JSON.stringify(data))
+
+describe('hydrate and filter', () => {
+  let entries, filtered
+  beforeEach(async () => {
+    cozy.data.query.mockReturnValue(asyncResolve([
+      {_id: 1, name: 'Marge', _rev: 2},
+      {_id: 2, name: 'Homer', _rev: 3}
+    ]))
+    cozy.data.defineIndex.mockReturnValue(asyncResolve())
+  })
+
+  const setup = async _entries => {
+  }
+
+  it('should hydrate entries with info from db', async () => {
+    entries = copy(basicEntries)
+    filtered = await hydrateAndFilter(entries, 'io.cozy.simpsons', { keys: ['name'] })
+    expect(entries[0]._id).toBe(1)
+    expect(entries[0]._rev).toBe(2)
+    expect(entries[1]._id).toBe(2)
+    expect(entries[1]._rev).toBe(3)
+    expect(filtered.length).toBe(3)
+  })
+
+  it('should support shouldSave / shouldUpdate as options', async () => {
+    entries = copy(basicEntries)
+    filtered = await hydrateAndFilter(entries, 'io.cozy.simpsons', {
+      keys: ['name'],
+      shouldSave: entry => {
+        return entry.name !== 'Bart'
+      },
+      shouldUpdate: (entry, existing) => {
+        return entry.name === 'Marge'
+      }
+    })
+    expect(filtered.filter(x => x.name == 'Bart').length).toBe(0)
+    expect(filtered.filter(x => x.name == 'Marge').length).toBe(1)
+  })
+
+  it('should support shouldSave / shouldUpdate in the entries', async () => {
+    class Simpson extends Document {
+      shouldSave () {
+        return this.name !== 'Bart'
+      }
+
+      shouldUpdate () {
+        return this.name === 'Marge'
+      }
+    }
+
+    entries = copy(basicEntries).map(x => new Simpson(x))
+    filtered = await hydrateAndFilter(entries, 'io.cozy.simpsons', {
+      keys: ['name']
+    })
+    expect(filtered.filter(x => x.name == 'Bart').length).toBe(0)
+    expect(filtered.filter(x => x.name == 'Marge').length).toBe(1)
+  })
+})

--- a/libs/linkBankOperations.js
+++ b/libs/linkBankOperations.js
@@ -21,7 +21,6 @@ class Linker {
     this.cozyClient = cozyClient
   }
 
-  // TODO: to rename addBillToDebitOperation
   addBillToOperation (bill, operation) {
     if (!bill._id) {
       log('warn', 'bill has no id, impossible to add it to an operation')
@@ -43,7 +42,6 @@ class Linker {
     )
   }
 
-  // TODO: to rename addBillToCreditOperation
   addReimbursementToOperation (bill, debitOperation, matchingOperation) {
     if (!bill._id) {
       log('warn', 'bill has no id, impossible to add it as a reimbursement')

--- a/libs/linkBankOperations.js
+++ b/libs/linkBankOperations.js
@@ -102,18 +102,17 @@ class Linker {
       const linkBillToCreditOperation = debitOperation => {
         return findCreditOperation(this.cozyClient, bill, options)
           .then(creditOperation => {
-            const creditPromise = Promise.resolve()
+            const promises = []
             if (creditOperation) {
               res.creditOperation = creditOperation
-              creditPromise.then(() => this.addBillToOperation(bill, creditOperation))
+              promises.push(this.addBillToOperation(bill, creditOperation))
             }
-            const debitPromise = Promise.resolve()
             if (creditOperation && debitOperation) {
               log('debug', bill, 'Matching bill')
               log('debug', creditOperation, 'Matching credit creditOperation')
-              debitPromise.then(() => this.addReimbursementToOperation(bill, debitOperation, creditOperation))
+              promises.push(this.addReimbursementToOperation(bill, debitOperation, creditOperation))
             }
-            return Promise.all([creditOperation, debitOperation])
+            return Promise.all(promises)
           })
       }
 

--- a/libs/linkBankOperations.spec.js
+++ b/libs/linkBankOperations.spec.js
@@ -169,7 +169,7 @@ describe('linker', () => {
       })
     })
 
-    test('health bills with not debit operation found should associate credit operation', () => {
+    test('health bills with not debit operation found should be associated with a credit operation', () => {
       const healthBills = [
         {
           _id: 'b1',

--- a/libs/linkBankOperations.spec.js
+++ b/libs/linkBankOperations.spec.js
@@ -160,11 +160,13 @@ describe('linker', () => {
         expect(result).toEqual({
           b1: { creditOperation: operations[1], debitOperation: operations[0] }
         })
-        expect(operations[0]).toMatchObject({reimbursements: [{
-          billId: 'io.cozy.bills:b1',
-          amount: 5,
-          operationId: 'o2'
-        }]})
+        expect(operations[0]).toMatchObject({
+          reimbursements: [{
+            billId: 'io.cozy.bills:b1',
+            amount: 5,
+            operationId: 'o2'
+          }
+        ]})
         expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1']})
       })
     })
@@ -191,6 +193,70 @@ describe('linker', () => {
         expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1']})
       })
     })
+
+    describe('health bill with group amount', () => {
+      // Bills that have been reimbursed at the same date in the same
+      // "bundle" have a "groupAmount" that is matched against
+      // the debit operation
+      const healthBills = [
+        {
+          _id: 'b1',
+          amount: 3.5,
+          groupAmount: 5,
+          originalAmount: 20,
+          type: 'health_costs',
+          originalDate: new Date(2017, 11, 13),
+          date: new Date(2017, 11, 15),
+          isRefund: true,
+          vendor: 'Ameli'
+        },
+        {
+          _id: 'b2',
+          amount: 1.5,
+          groupAmount: 5,
+          originalAmount: 20,
+          type: 'health_costs',
+          originalDate: new Date(2017, 11, 14),
+          date: new Date(2017, 11, 16),
+          isRefund: true,
+          vendor: 'Ameli'
+        }
+      ]
+
+      describe('with corresponding credit operation', () => {
+        it('should be associated with the right credit operation', () => {
+
+          const options = { ...defaultOptions, identifiers: ['CPAM'] }
+          return linker.linkBillsToOperations(healthBills, options)
+            .then(result => {
+              const debitOperation = expect.any(Object)
+              expect(result).toMatchObject({
+                b1: { creditOperation: operations[1], debitOperation },
+                b2: { creditOperation: operations[1], debitOperation  }
+              })
+              expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1', 'io.cozy.bills:b2']})
+              expect(result.b1.debitOperation).toBe(result.b2.debitOperation)
+              expect(result.b1.debitOperation.reimbursements.length).toBe(2)
+            })
+        })
+      })
+
+      describe('without corresponding credit operation', () => {
+        it('should be associated with the right credit operation', () => {
+          const healthBills2 = healthBills.map(x => ({...x, originalAmount: 999}))
+          const options = { ...defaultOptions, identifiers: ['CPAM'] }
+          return linker.linkBillsToOperations(healthBills2, options)
+            .then(result => {
+              expect(result).toEqual({
+                b1: { creditOperation: operations[1], debitOperation: undefined },
+                b2: { creditOperation: operations[1], debitOperation: undefined }
+              })
+              expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1', 'io.cozy.bills:b2']})
+            })
+        })
+      })
+    })
+
 
     test('not health bills', () => {
       const noHealthBills = [

--- a/libs/linker/billsToOperation/helpers.js
+++ b/libs/linker/billsToOperation/helpers.js
@@ -5,7 +5,7 @@ const differenceInDays = require('date-fns/difference_in_days')
 
 const getOperationAmountFromBill = (bill, options) => {
   const isCredit = options && options.credit
-  return isCredit ? bill.amount : -(bill.originalAmount || bill.amount)
+  return isCredit ? (bill.groupAmount || bill.amount) : -(bill.originalAmount || bill.amount)
 }
 
 const getOperationDateFromBill = (bill, options) => {

--- a/libs/saveBills.js
+++ b/libs/saveBills.js
@@ -24,7 +24,7 @@ module.exports = (entries, fields, options = {}) => {
   }
 
   // Deduplicate on this keys
-  options.keys = ['date', 'amount', 'vendor']
+  options.keys = options.keys || ['date', 'amount', 'vendor']
 
   options.postProcess = function (entry) {
     if (entry.fileDocument) {


### PR DESCRIPTION
Allow credit bill to be matched against `groupAmount` attribute of banking operation.

A credit bill has a `groupAmount` attribute in case of bundled reimbursements. This is the attribute that needs to be matched with the banking operation.

