### PR TITLE
Handle group amount

### DIFF
--- a/libs/linkBankOperations.js
+++ b/libs/linkBankOperations.js
@@ -21,7 +21,6 @@ class Linker {
     this.cozyClient = cozyClient
   }
 
-  // TODO: to rename addBillToDebitOperation
   addBillToOperation (bill, operation) {
     if (!bill._id) {
       log('warn', 'bill has no id, impossible to add it to an operation')
@@ -43,7 +42,6 @@ class Linker {
     )
   }
 
-  // TODO: to rename addBillToCreditOperation
   addReimbursementToOperation (bill, debitOperation, matchingOperation) {
     if (!bill._id) {
       log('warn', 'bill has no id, impossible to add it as a reimbursement')

--- a/libs/linkBankOperations.js
+++ b/libs/linkBankOperations.js
@@ -102,18 +102,17 @@ class Linker {
       const linkBillToCreditOperation = debitOperation => {
         return findCreditOperation(this.cozyClient, bill, options)
           .then(creditOperation => {
-            const creditPromise = Promise.resolve()
+            const promises = []
             if (creditOperation) {
               res.creditOperation = creditOperation
-              creditPromise.then(() => this.addBillToOperation(bill, creditOperation))
+              promises.push(this.addBillToOperation(bill, creditOperation))
             }
-            const debitPromise = Promise.resolve()
             if (creditOperation && debitOperation) {
               log('debug', bill, 'Matching bill')
               log('debug', creditOperation, 'Matching credit creditOperation')
-              debitPromise.then(() => this.addReimbursementToOperation(bill, debitOperation, creditOperation))
+              promises.push(this.addReimbursementToOperation(bill, debitOperation, creditOperation))
             }
-            return Promise.all([creditOperation, debitOperation])
+            return Promise.all(promises)
           })
       }
 

--- a/libs/linkBankOperations.spec.js
+++ b/libs/linkBankOperations.spec.js
@@ -169,7 +169,7 @@ describe('linker', () => {
       })
     })
 
-    test('health bills with not debit operation found should associate credit operation', () => {
+    test('health bills with not debit operation found should be associated with a credit operation', () => {
       const healthBills = [
         {
           _id: 'b1',

--- a/libs/linkBankOperations.spec.js
+++ b/libs/linkBankOperations.spec.js
@@ -160,11 +160,13 @@ describe('linker', () => {
         expect(result).toEqual({
           b1: { creditOperation: operations[1], debitOperation: operations[0] }
         })
-        expect(operations[0]).toMatchObject({reimbursements: [{
-          billId: 'io.cozy.bills:b1',
-          amount: 5,
-          operationId: 'o2'
-        }]})
+        expect(operations[0]).toMatchObject({
+          reimbursements: [{
+            billId: 'io.cozy.bills:b1',
+            amount: 5,
+            operationId: 'o2'
+          }
+        ]})
         expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1']})
       })
     })
@@ -191,6 +193,69 @@ describe('linker', () => {
         expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1']})
       })
     })
+
+    describe('health bill with group amount', () => {
+      // Bills that have been reimbursed at the same date in the same
+      // "bundle" have a "groupAmount" that is matched against
+      // the debit operation
+      const healthBills = [
+        {
+          _id: 'b1',
+          amount: 3.5,
+          groupAmount: 5,
+          originalAmount: 20,
+          type: 'health_costs',
+          originalDate: new Date(2017, 11, 13),
+          date: new Date(2017, 11, 15),
+          isRefund: true,
+          vendor: 'Ameli'
+        },
+        {
+          _id: 'b2',
+          amount: 1.5,
+          groupAmount: 5,
+          originalAmount: 20,
+          type: 'health_costs',
+          originalDate: new Date(2017, 11, 14),
+          date: new Date(2017, 11, 16),
+          isRefund: true,
+          vendor: 'Ameli'
+        }
+      ]
+
+      describe('with corresponding debit operation', () => {
+        it('should be associated with the right operations', () => {
+          const options = { ...defaultOptions, identifiers: ['CPAM'] }
+          return linker.linkBillsToOperations(healthBills, options)
+            .then(result => {
+              const debitOperation = expect.any(Object)
+              expect(result).toMatchObject({
+                b1: { creditOperation: operations[1], debitOperation },
+                b2: { creditOperation: operations[1], debitOperation  }
+              })
+              expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1', 'io.cozy.bills:b2']})
+              expect(result.b1.debitOperation).toBe(result.b2.debitOperation)
+              expect(result.b1.debitOperation.reimbursements.length).toBe(2)
+            })
+        })
+      })
+
+      describe('without corresponding debit operation', () => {
+        it('should be associated with the right credit operation', () => {
+          const healthBills2 = healthBills.map(x => ({...x, originalAmount: 999}))
+          const options = { ...defaultOptions, identifiers: ['CPAM'] }
+          return linker.linkBillsToOperations(healthBills2, options)
+            .then(result => {
+              expect(result).toEqual({
+                b1: { creditOperation: operations[1], debitOperation: undefined },
+                b2: { creditOperation: operations[1], debitOperation: undefined }
+              })
+              expect(operations[1]).toMatchObject({bills: ['io.cozy.bills:b1', 'io.cozy.bills:b2']})
+            })
+        })
+      })
+    })
+
 
     test('not health bills', () => {
       const noHealthBills = [

--- a/libs/linker/billsToOperation/helpers.js
+++ b/libs/linker/billsToOperation/helpers.js
@@ -5,7 +5,7 @@ const differenceInDays = require('date-fns/difference_in_days')
 
 const getOperationAmountFromBill = (bill, options) => {
   const isCredit = options && options.credit
-  return isCredit ? bill.amount : -(bill.originalAmount || bill.amount)
+  return isCredit ? (bill.groupAmount || bill.amount) : -(bill.originalAmount || bill.amount)
 }
 
 const getOperationDateFromBill = (bill, options) => {


### PR DESCRIPTION
Allow credit bill to be matched against `groupAmount` attribute of banking operation.

A credit bill has a `groupAmount` attribute in case of bundled reimbursements. This is the attribute that needs to be matched with the banking operation.