### PR TITLE
saveFiles handle filestream

### DIFF
--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -42,6 +42,12 @@ const USER_ACTION_NEEDED = 'USER_ACTION_NEEDED'
  */
 const FILE_DOWNLOAD_FAILED = 'FILE_DOWNLOAD_FAILED'
 
+/**
+ * There was a problem while saving a file
+ * @type {String}
+ */
+const SAVE_FILE_FAILED = 'SAVE_FILE_FAILED'
+
 module.exports = {
   MSG: MSG,
   LOGIN_FAILED,
@@ -49,5 +55,6 @@ module.exports = {
   VENDOR_DOWN,
   USER_ACTION_NEEDED,
   FILE_DOWNLOAD_FAILED,
-  requireTwoFactor: requireTwoFactor
+  requireTwoFactor: requireTwoFactor,
+  SAVE_FILE_FAILED
 }

--- a/libs/saveFiles.js
+++ b/libs/saveFiles.js
@@ -167,6 +167,7 @@ function getFileName (entry) {
   if (entry.filename) {
     filename = entry.filename
   } else if (entry.filestream) {
+    log('debug', entry)
     throw new Error('Missing filename property')
   } else {
     // try to get the file name from the url

--- a/libs/saveFiles.js
+++ b/libs/saveFiles.js
@@ -73,11 +73,8 @@ const createFile = function (entry, options) {
         contentType: options.contentType
       }
 
-      if (entry.filestream) {
-        return cozy.files.create(entry.filestream, createFileOptions)
-      }
-
-      return cozy.files.create(downloadEntry(entry, options), createFileOptions)
+      const toCreate = entry.filestream || downloadEntry(entry, options)
+      return cozy.files.create(toCreate, createFileOptions)
     })
     .then(fileDocument => {
       // This allows us to have the warning message at the first run
@@ -93,7 +90,9 @@ const attachFileToEntry = function (entry, fileDocument) {
 }
 
 const saveEntry = function (entry, options) {
-  if (!entry.fileurl && !entry.requestOptions && !entry.filestream) return entry
+  const canBeSaved = entry => entry.fileurl || entry.requestOptions || entry.filestream
+
+  if (!canBeSaved(entry)) { return entry }
 
   if (options.timeout && Date.now() > options.timeout) {
     const remainingTime = Math.floor((options.timeout - Date.now()) / 1000)

--- a/libs/saveFiles.js
+++ b/libs/saveFiles.js
@@ -129,7 +129,7 @@ const saveEntry = function (entry, options) {
       return options.postProcess ? options.postProcess(entry) : entry
     })
     .catch(err => {
-      log('warn', errors.FILE_DOWNLOAD_FAILED)
+      log('warn', errors.SAVE_FILE_FAILED)
       log('warn', err.message, `Error caught while trying to save the file ${entry.fileurl ? entry.fileurl : entry.filename}`)
       return entry
     })

--- a/libs/saveFiles.spec.js
+++ b/libs/saveFiles.spec.js
@@ -40,6 +40,14 @@ const billFixtures = [
     fileurl:
       'https://mobile.free.fr/moncompte/index.php?page=suiviconso&action=getFacture&format=dl&l=14730097&id=0ca5e5537786bc548a87a89eba2a804a&date=20170113&multi=0',
     filename: '201701_freemobile.pdf'
+  },
+  {
+    amount: 49.32,
+    date: '2018-03-03T23:00:00.000Z',
+    vendor: 'Free Mobile',
+    type: 'phone',
+    filestream: 'mock stream',
+    filename: '201701_freemobile.pdf'
   }
 ]
 
@@ -47,7 +55,7 @@ const FOLDER_PATH = '/testfolder'
 const options = { folderPath: FOLDER_PATH }
 let bills
 
-beforeEach(async function() {
+beforeEach(async function () {
   const INDEX = 'index'
   bills = billFixtures
   cozyClient.data.defineIndex.mockReturnValue(() => asyncResolve(INDEX))
@@ -58,7 +66,7 @@ beforeEach(async function() {
   })
 })
 
-describe('saveFiles', function() {
+describe('saveFiles', function () {
   const makeFile = (_id, attributes) => ({ _id, attributes })
   const rightMimeFile = makeFile('existingFileId', {
     name: '201701_freemobile.pdf',
@@ -98,15 +106,15 @@ describe('saveFiles', function() {
       beforeEach(async () => {
         cozyClient.files.statByPath.mockImplementation(path => {
           // Must check if we are stating on the folder or on the file
-          return path == FOLDER_PATH ?
-            asyncResolve({ _id: 'folderId' }) :
-            asyncResolve(existingFile)
+          return path === FOLDER_PATH
+            ? asyncResolve({ _id: 'folderId' })
+            : asyncResolve(existingFile)
         })
         await saveFiles(bills, options)
       })
 
       // Whether a file should be created or not
-      it(`should${expectCreation ? ' ' : ' not ' }create a file`, async function() {
+      it(`should${expectCreation ? ' ' : ' not '}create a file`, async function () {
         if (expectCreation) {
           expect(cozyClient.files.create).toHaveBeenCalledTimes(bills.length)
         } else {
@@ -122,4 +130,37 @@ describe('saveFiles', function() {
       })
     })
   }
+
+  const billWithoutFilename = [{
+    amount: 62.93,
+    date: '2018-03-03T23:00:00.000Z',
+    vendor: 'Free Mobile',
+    type: 'phone',
+    filestream: 'mock stream'
+  }]
+  describe('when filestream is used without filename', () => {
+    it('should throw an error', async () => {
+      expect.assertions(2)
+      try {
+        await saveFiles(billWithoutFilename, options)
+      } catch (error) {
+        expect(error).toEqual(new Error('Missing filename property'))
+      }
+      expect(cozyClient.files.create).not.toHaveBeenCalled()
+    })
+  })
+
+  const billWithoutStreamUrlAndRequestOptions = [{
+    amount: 62.93,
+    date: '2018-03-03T23:00:00.000Z',
+    vendor: 'Free Mobile',
+    type: 'phone'
+  }]
+  describe('when filestream is used without filename', () => {
+    it('should throw an error', async () => {
+      expect.assertions(1)
+      await saveFiles(billWithoutStreamUrlAndRequestOptions, options)
+      expect(cozyClient.files.create).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/libs/saveFiles.spec.js
+++ b/libs/saveFiles.spec.js
@@ -156,8 +156,8 @@ describe('saveFiles', function () {
     vendor: 'Free Mobile',
     type: 'phone'
   }]
-  describe('when filestream is used without filename', () => {
-    it('should throw an error', async () => {
+  describe('when entry doesn\'t have file creation information', () => {
+    it('should do nothing', async () => {
       expect.assertions(1)
       await saveFiles(billWithoutStreamUrlAndRequestOptions, options)
       expect(cozyClient.files.create).not.toHaveBeenCalled()

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "lint": "standard --fix commands/* helpers/* libs/* index.js",
-    "test": "env LOG_LEVEL=info jest",
+    "test": "cross-env LOG_LEVEL=info jest",
     "doc": "jsdoc2md --template jsdoc2md/README.hbs libs/*.js helpers/*.js > docs/api.md"
   },
   "standard": {
@@ -62,5 +62,8 @@
       "expect",
       "it"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^5.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,7 +991,14 @@ cozy-client-js@^0.3.17:
   version "0.3.18"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.18.tgz#754ed71c6f5804d63b402cc78b842de12eccbb9b"
 
-cross-spawn@^5.0.1:
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1713,6 +1720,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-wsl@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fix #90 

If the entry has a `filestream` attribute the file is created directly without download.

I just have some remarks:
- I have added the cross-env lib to handle the environment variable in the `test` script, but I could reverse it if necessary
- I throw a new error at line 170, should I create a new error in the `errors.js` file? Or handle it differently?
- At line 113, the error `BAD_DOWNLOADED_FILE` is thrown but since the file isn't always downloaded, should that be modified too?