### PR TITLE
fix: remove promise check in BaseKonnector

### DIFF
--- a/libs/BaseKonnector.js
+++ b/libs/BaseKonnector.js
@@ -63,13 +63,6 @@ class BaseKonnector {
   run () {
     return this.init()
     .then(requiredFields => this.fetch(requiredFields))
-    .then(prom => {
-      if (!prom || !prom.then) {
-        log('warn', `A promise should be returned from the \`fetch\` function. Here ${prom} was returned`)
-        throw new Error('`fetch` should return a Promise')
-      }
-      return prom
-    })
     .then(this.end)
     .catch(this.fail.bind(this))
   }


### PR DESCRIPTION
This check never works since if the fetch function returns a promise, it will get the result of
the promise, which will not be a promise.