### PR TITLE
✨ feat: add scrape method for declarative scraping

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
   requestFactory,
   retry: require('bluebird-retry'),
   wrapIfSentrySetUp: require('./helpers/sentry').wrapIfSentrySetUp,
-  Document: require('./libs/document')
+  Document: require('./libs/document'),
+  scrape: require('./libs/scrape')
 }
 
 function deprecate (wrapped, message) {

--- a/libs/scrape.js
+++ b/libs/scrape.js
@@ -1,0 +1,67 @@
+/**
+ * Declarative scraping.
+ *
+ * Describe your items attributes and where to find/parse them
+ * instead of imperatively building them.
+ *
+ * Heavily inspired by [artoo] scraping method.
+ *
+ * [artoo]: https://medialab.github.io/artoo/
+ */
+
+const mkSpec = function(spec) {
+  if (typeof spec === "string") {
+    return { sel: spec };
+  } else {
+    return spec;
+  }
+};
+
+/**
+ * Scrape a cheerio object for properties
+ *
+ * @param  {cheerio} $ - Cheerio node which will be scraped
+ * @param  {object|string} spec(s) - Options object describing what you want to scrape
+ * @param  {string} [childSelector] -  If passed, scrape will return an array of items
+ * @return {object|array} - Item(s) scraped
+ */
+const scrape = ($, specs, childSelector) => {
+  // Only one value shorthand
+  if (
+    typeof specs === "string" ||
+    (specs.sel && typeof specs.sel === "string")
+  ) {
+    const { val } = scrape($, { val: specs });
+    return val;
+  }
+
+  // Several items shorthand
+  if (childSelector !== undefined) {
+    return ($.find || $)(childSelector).map((i, e) => scrape($(e), specs));
+  }
+
+  // Several properties "normal" case
+  const res = {};
+  Object.keys(specs).forEach(specName => {
+    const spec = mkSpec(specs[specName]);
+    let data = spec.sel ? $.find(spec.sel) : $;
+    if (spec.index) {
+      data = data.get(spec.index);
+    }
+    let val;
+    if (spec.fn) {
+      val = spec.fn(data);
+    } else if (spec.attr) {
+      val = data.attr(spec.attr);
+    } else {
+      val = data.text().trim();
+    }
+    if (spec.parse) {
+      val = spec.parse(val);
+    }
+    res[specName] = val;
+  });
+  return res;
+};
+
+module.exports = scrape;

--- a/libs/scrape.js
+++ b/libs/scrape.js
@@ -37,7 +37,7 @@ const scrape = ($, specs, childSelector) => {
 
   // Several items shorthand
   if (childSelector !== undefined) {
-    return ($.find || $)(childSelector).map((i, e) => scrape($(e), specs));
+    return Array.from(($.find || $)(childSelector)).map(e => scrape($(e), specs));
   }
 
   // Several properties "normal" case

--- a/libs/scrape.spec.js
+++ b/libs/scrape.spec.js
@@ -1,0 +1,90 @@
+const html = `
+<div class="article">
+  <div class="title" href="title1">Header 1</div>
+  <div class="content">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Reiciendis a iure, dolorem atque illo explicabo, consectetur pariatur quaerat, hic molestias excepturi esse. Sapiente molestias, magni veniam facilis ipsa cumque laboriosam.</div>
+</div>
+<div class="article">
+  <div class="title" href="title2">Header 2</div>
+  <div class="content">Natus fugiat cupiditate voluptates eligendi, saepe, explicabo numquam. Labore consectetur sit incidunt, odio, saepe, nam magni alias ipsa, itaque temporibus facilis! Veniam sint doloremque, enim quia optio expedita consequuntur quo!</div>
+</div>
+<div class="article">
+  <div class="title" href="title3">Header 3</div>
+  <div class="content">Ducimus labore eligendi et corrupti fugiat perferendis iusto inventore voluptatum, ullam dolorem officia assumenda quisquam adipisci aut nesciunt vitae aliquam molestias asperiores, quaerat. Neque quam in, earum ea laborum dignissimos.</div>
+</div>
+<div class="article">
+  <div class="title" href="title4">Header 4</div>
+  <div class="content">Ab laudantium nemo delectus quae, debitis fuga obcaecati, asperiores inventore. Eligendi consequatur iure harum officia dolorem ad alias suscipit nemo, quaerat quis, iste cum? Consectetur animi officiis laboriosam impedit explicabo.</div>
+</div>
+<div class="article">
+  <div class="title" href="title5">Header 5</div>
+  <div class="content">Itaque debitis reiciendis nobis voluptatibus, aliquam, quidem in molestiae! In obcaecati ullam ratione molestias quidem voluptas neque tenetur, aut totam perspiciatis tempora animi maxime magni praesentium vitae, optio, iste nulla.</div>
+</div>
+`;
+
+const cheerio = require("cheerio");
+const scrape = require("./scrape");
+
+describe("scrape", () => {
+  let $;
+  beforeEach(() => {
+    $ = cheerio.load(html);
+  });
+
+  it("should be able to scrape 1 element", () => {
+    const article = $(".article").eq(0);
+    const title = scrape(article, ".title");
+    expect(title).toBe("Header 1");
+  });
+
+  it("should be able to parse", () => {
+    const article = $(".article").eq(0);
+    const title = scrape(article, {
+      sel: ".title",
+      parse: val => val.toUpperCase()
+    });
+    expect(title).toBe("HEADER 1");
+  });
+
+  it("should be able to return several properties", () => {
+    const article = $(".article").eq(0);
+    const specs = {
+      title: ".title",
+      titleHref: { sel: ".title", attr: "href" },
+      content: ".content"
+    };
+
+    const attrs = scrape(article, specs);
+    expect(attrs.title).toBe("Header 1");
+    expect(attrs.content.slice(0, 5)).toBe("Lorem");
+  });
+
+  it("should be able to scrape several elements", () => {
+    const specs = {
+      title: ".title",
+      titleHref: { sel: ".title", attr: "href" },
+      content: ".content"
+    };
+
+    const items = scrape($, specs, ".article");
+    expect(items[0].title).toBe("Header 1");
+    expect(items[0].titleHref).toBe("title1");
+
+    const content = items[0].content;
+    const l = content.length;
+    expect(content.slice(0, 5)).toBe("Lorem");
+    expect(content.substr(l - 11, l)).toBe("laboriosam.");
+  });
+
+  it("should be possible to pass a custom function", () => {
+    const specs = {
+      title: {
+        sel: ".title",
+        fn: $this => {
+          return $this.attr("href") + ":" + $this.text().trim();
+        }
+      }
+    };
+    const item = scrape($(".article").eq(0), specs);
+    expect(item.title).toBe("title1:Header 1");
+  });
+});


### PR DESCRIPTION
The scrape method allows declarative scraping.

Declarative scraping is good at it could allow us to build interfaces for people to more easily build a konnector.

```js
import { scrape } from 'cozy-konnector-libs'

const $ = cheerio.load(html)
scrape($, {
  title: '.title',
  content: '.content',
  link: {
    sel: 'a',
    attr: 'href',
    index: 0
  }
})
// -> {
//   title: 'Adam Ondra',
//   content: 'Adam Ondra is the first climber to ever climb 9C.',
//   link: 'https://fr.wikipedia.org/wiki/Adam_Ondra'
// }
"
```

It is heavily inspired (almost copied the API) by [artoo].

It also allows to scrape several items in one go via its third parameter. 

```js
scrape($, { title: '.title'}, '.articles')
// -> [{ title: 'a' }, { title: 'b'}, { title: 'c'}]
```

Check the tests ;)

[artoo]: https://medialab.github.io/artoo/scrape/#scrape 