### PR TITLE
Pass `encoding` option to requestFactory instance

### DIFF
--- a/libs/request.js
+++ b/libs/request.js
@@ -84,6 +84,7 @@ module.exports = function (options = {}) {
   requestOptions.headers = options.headers
   requestOptions.followAllRedirects = options.followAllRedirects
   requestOptions.strictSSL = options.strictSSL
+  requestOptions.encoding = options.encoding
 
   if (options.cheerio) {
     // a lot of web service do not want to be called by robots and then check the user agent to


### PR DESCRIPTION
This would allow to define a website-wide encoding from the factory definition.

[Request documentation](https://github.com/request/request#requestoptions-callback)

> encoding - encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the **default value of undefined**) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)

Accessing to `options.encoding` if not defined by user would not alter the `request` behavior as it would pass `undefined` as a value.

This would fix https://github.com/carrieje/cozy-konnector-connection/issues/1