### PR TITLE
Provide signon helper to the user

### DIFF
--- a/packages/cozy-konnector-libs/index.js
+++ b/packages/cozy-konnector-libs/index.js
@@ -21,6 +21,7 @@ module.exports = {
   retry: require('bluebird-retry'),
   wrapIfSentrySetUp: require('./helpers/sentry').wrapIfSentrySetUp,
   Document: require('./libs/document'),
+  signon: require('./libs/signon'),
   scrape: require('./libs/scrape')
 }
 

--- a/packages/cozy-konnector-libs/index.js
+++ b/packages/cozy-konnector-libs/index.js
@@ -21,7 +21,7 @@ module.exports = {
   retry: require('bluebird-retry'),
   wrapIfSentrySetUp: require('./helpers/sentry').wrapIfSentrySetUp,
   Document: require('./libs/document'),
-  signon: require('./libs/signon'),
+  signin: require('./libs/signin'),
   scrape: require('./libs/scrape')
 }
 

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -53,17 +53,17 @@ module.exports = function signin (
   validate = defaultValidate,
   opts = {})
 {
-  const defaultOpts = { jar: true, cheerio: true, json: false }
-
   const rq = requestFactory({
-    ...opts,
-    ...defaultOpts
+    jar: true,
+    ...opts
   })
 
   const parseBody = getStrategy(parse)
 
-  return rq(pageUrl)
-    .catch(handleRequestErrors)
+  return rq({
+    uri: pageUrl,
+    cheerio: true
+  }).catch(handleRequestErrors)
     .then($ => {
       const [action, inputs] = parseForm($, formSelector)
       for (let name in formData) {

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -53,7 +53,7 @@ module.exports = function signin (
     ...defaultOpts
   })
 
-  const parseBody = defineStrategy(parseStrategy)
+  const parseBody = getStrategy(parseStrategy)
 
   return rq(`${baseUrl}/${page}`)
   .then($ => {
@@ -77,7 +77,7 @@ function defaultValidate (statusCode, body) {
   return statusCode === 200
 }
 
-function defineStrategy (parseStrategy) {
+function getStrategy (parseStrategy) {
   switch (parseStrategy) {
     case 'cheerio':
       return require('cheerio').load

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -4,7 +4,7 @@
  * failure, it throws a `LOGIN_FAILED` error.
  *
  * It does not submit values provided through `select` tags, except if populated
- * by user with `population`.
+ * by user with `formData`.
  * Limit between `baseUrl` and `page` is important. The form `action` will be
  * concatenated the same way `page` is, to constitute the submission url. For
  * now, a form with an absolute `action` is not comptabile with this function.
@@ -14,7 +14,7 @@
  * - `formSelector` is used by cheerio to uniquely identify the form in which to
  *   log in
  *
- * - `population` is an object of { name: value, … }. It is used to populate the
+ * - `formData` is an object of { name: value, … }. It is used to populate the
  *   form, in the proper inputs with the same name as the properties of this
  *   object, before submitting it.
  *
@@ -39,7 +39,7 @@ const url = require('url')
 module.exports = function signin (
   pageUrl,
   formSelector,
-  population,
+  formData,
   parseStrategy = 'cheerio',
   validate = defaultValidate,
   opts = {}) {
@@ -56,8 +56,8 @@ module.exports = function signin (
   return rq(pageUrl)
   .then($ => {
     const [action, inputs] = parseForm($, formSelector)
-    for (let name in population) {
-      inputs[name] = population[name]
+    for (let name in formData) {
+      inputs[name] = formData[name]
     }
 
     return submitForm(rq, url.resolve(pageUrl, action), inputs, parseBody)

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -34,7 +34,7 @@
  *   `parsedBody`. If it is false, `LOGIN_FAILED` is thrown, otherwise the
  *   konnector continues.
  *
- * - `opts` allows to pass eventual options to the `signin`'s `requestFactory`.
+ * - `requestOpts` allows to pass eventual options to the `signin`'s `requestFactory`.
  *   It could be useful for pages using `latin1` `encoding` for instance.
  *
  * @module signin
@@ -52,12 +52,12 @@ module.exports = function signin (
   {
     parse = 'cheerio',
     validate = defaultValidate,
-    ...opts
+    ...requestOpts
   } = {})
 {
   const rq = requestFactory({
     jar: true,
-    ...opts
+    ...requestOpt
   })
 
   const parseBody = getStrategy(parse)

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -54,6 +54,14 @@ module.exports = function signin (
     ...requestOpts
   } = {})
 {
+  // Check for mandatory arguments
+  if (url === undefined) {
+    throw 'signin: `url` must be defined'
+  }
+  if (formSelector === undefined) {
+    throw 'signin: `formSelector` must be defined'
+  }
+
   const rq = requestFactory({
     jar: true,
     ...requestOpts

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -49,9 +49,11 @@ module.exports = function signin (
   pageUrl,
   formSelector,
   formData,
-  parse = 'cheerio',
-  validate = defaultValidate,
-  opts = {})
+  {
+    parse = 'cheerio',
+    validate = defaultValidate,
+    ...opts
+  } = {})
 {
   const rq = requestFactory({
     jar: true,

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -83,12 +83,12 @@ function getStrategy (parseStrategy) {
       return require('cheerio').load
     case 'json':
       return JSON.parse
-    default:
-      let err = `connection: parsing strategy ${parseStrategy} unknown. `
-      let fallback = 'Falling back to `raw`. Use one of `raw`, `cheerio` or `json`'
-      log('warn', err + fallback)
     case 'raw':
       return (body) => body
+    default:
+      const err = `signin: parsing strategy ${parseStrategy} unknown. `
+      const hint = 'Use one of `raw`, `cheerio` or `json`'
+      log('error', err + hint)
   }
 }
 

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -45,10 +45,10 @@ const log = require('cozy-logger').namespace('cozy-konnector-libs')
 const requestFactory = require('./request')
 
 module.exports = function signin (
-  url,
-  formSelector,
-  formData,
   {
+    url,
+    formSelector,
+    formData = {},
     parse = 'cheerio',
     validate = defaultValidate,
     ...requestOpts

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -17,7 +17,7 @@
  * concatenated the same way `page` is, to constitute the submission url. For
  * now, a form with an absolute `action` is not comptabile with this function.
  *
- * - `pageUrl` is the url to access the html form
+ * - `url` is the url to access the html form
  *
  * - `formSelector` is used by cheerio to uniquely identify the form in which to
  *   log in
@@ -43,10 +43,9 @@ const errors = require('../helpers/errors')
 const rerrors = require('request-promise/errors')
 const log = require('cozy-logger').namespace('cozy-konnector-libs')
 const requestFactory = require('./request')
-const url = require('url')
 
 module.exports = function signin (
-  pageUrl,
+  url,
   formSelector,
   formData,
   {
@@ -57,13 +56,13 @@ module.exports = function signin (
 {
   const rq = requestFactory({
     jar: true,
-    ...requestOpt
+    ...requestOpts
   })
 
   const parseBody = getStrategy(parse)
 
   return rq({
-    uri: pageUrl,
+    uri: url,
     cheerio: true
   }).catch(handleRequestErrors)
     .then($ => {
@@ -72,7 +71,7 @@ module.exports = function signin (
         inputs[name] = formData[name]
       }
 
-      return submitForm(rq, url.resolve(pageUrl, action), inputs, parseBody)
+      return submitForm(rq, require('url').resolve(url, action), inputs, parseBody)
     })
     .then(([statusCode, parsedBody]) => {
       if (!validate(statusCode, parsedBody)) {

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -1,7 +1,15 @@
 /**
  * The goal of this function is to provide an handy method to log the user in,
- * on html form pages. On success, it resolves a promise with a parsed body. On
- * failure, it throws a `LOGIN_FAILED` error.
+ * on html form pages. On success, it resolves a promise with a parsed body.
+ *
+ * Errors:
+ *
+ * - LOGIN_FAILED if the validate predicate is false
+ * - INVALID_FORM if the element matched by `formSelector` is not a form or has
+ *   no `action` attribute
+ * - UNKNOWN_PARSING_STRATEGY if `parseStrategy` is not one of the accepted
+ *   values : `raw`, `cheerio`, `json`.
+ * - VENDOR_DOWN if a request throws a RequestError
  *
  * It does not submit values provided through `select` tags, except if populated
  * by user with `formData`.

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -9,9 +9,7 @@
  * concatenated the same way `page` is, to constitute the submission url. For
  * now, a form with an absolute `action` is not comptabile with this function.
  *
- * - `baseUrl` is the root of the url
- *
- * - `page` is concatenate (adding a `/`) to `baseUrl` to access the html form
+ * - `pageUrl` is the url to access the html form
  *
  * - `formSelector` is used by cheerio to uniquely identify the form in which to
  *   log in
@@ -36,10 +34,10 @@
 const errors = require('../helpers/errors')
 const log = require('cozy-logger').namespace('cozy-konnector-libs')
 const requestFactory = require('./request')
+const url = require('url')
 
 module.exports = function signin (
-  baseUrl,
-  page,
+  pageUrl,
   formSelector,
   population,
   parseStrategy = 'cheerio',
@@ -55,14 +53,14 @@ module.exports = function signin (
 
   const parseBody = getStrategy(parseStrategy)
 
-  return rq(`${baseUrl}/${page}`)
+  return rq(pageUrl)
   .then($ => {
     const [action, inputs] = parseForm($, formSelector)
     for (let name in population) {
       inputs[name] = population[name]
     }
 
-    return submitForm(rq, `${baseUrl}/${action}`, inputs, parseBody)
+    return submitForm(rq, url.resolve(pageUrl, action), inputs, parseBody)
   })
   .then(([statusCode, parsedBody]) => {
     if (!validate(statusCode, parsedBody)) {

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -20,7 +20,7 @@
  *   form, in the proper inputs with the same name as the properties of this
  *   object, before submitting it.
  *
- * - `parseStrategy` allow the user to resolve `signon` with a preparsed body.
+ * - `parseStrategy` allow the user to resolve `signin` with a preparsed body.
  *   The choice of the strategy for the parsing is one of : `raw`, `json` or
  *   `cheerio`. `cheerio` being the default.
  *
@@ -28,16 +28,16 @@
  *   `parsedBody`. If it is false, `LOGIN_FAILED` is thrown, otherwise the
  *   konnector continues.
  *
- * - `opts` allows to pass eventual options to the `signon`'s `requestFactory`.
+ * - `opts` allows to pass eventual options to the `signin`'s `requestFactory`.
  *   It could be useful for pages using `latin1` `encoding` for instance.
  *
- * @module signon
+ * @module signin
  */
 const errors = require('../helpers/errors')
 const log = require('cozy-logger').namespace('cozy-konnector-libs')
 const requestFactory = require('./request')
 
-module.exports = function signon (
+module.exports = function signin (
   baseUrl,
   page,
   formSelector,

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -49,7 +49,7 @@ module.exports = function signin (
   pageUrl,
   formSelector,
   formData,
-  parseStrategy = 'cheerio',
+  parse = 'cheerio',
   validate = defaultValidate,
   opts = {})
 {
@@ -60,7 +60,7 @@ module.exports = function signin (
     ...defaultOpts
   })
 
-  const parseBody = getStrategy(parseStrategy)
+  const parseBody = getStrategy(parse)
 
   return rq(pageUrl)
     .catch(handleRequestErrors)

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -7,35 +7,33 @@
  * - LOGIN_FAILED if the validate predicate is false
  * - INVALID_FORM if the element matched by `formSelector` is not a form or has
  *   no `action` attribute
- * - UNKNOWN_PARSING_STRATEGY if `parseStrategy` is not one of the accepted
- *   values : `raw`, `cheerio`, `json`.
- * - VENDOR_DOWN if a request throws a RequestError
+ * - UNKNOWN_PARSING_STRATEGY if `parse` is not one of the accepted values:
+ *   `raw`, `cheerio`, `json`.
+ * - VENDOR_DOWN if a request throws a RequestError, or StatusCodeError
  *
  * It does not submit values provided through `select` tags, except if populated
  * by user with `formData`.
- * Limit between `baseUrl` and `page` is important. The form `action` will be
- * concatenated the same way `page` is, to constitute the submission url. For
- * now, a form with an absolute `action` is not comptabile with this function.
  *
  * - `url` is the url to access the html form
  *
  * - `formSelector` is used by cheerio to uniquely identify the form in which to
  *   log in
  *
- * - `formData` is an object of { name: value, … }. It is used to populate the
+ * - `formData` is an object `{ name: value, … }`. It is used to populate the
  *   form, in the proper inputs with the same name as the properties of this
  *   object, before submitting it.
  *
- * - `parseStrategy` allow the user to resolve `signin` with a preparsed body.
- *   The choice of the strategy for the parsing is one of : `raw`, `json` or
+ * - `parse` allow the user to resolve `signin` with a preparsed body. The
+ *   choice of the strategy for the parsing is one of : `raw`, `json` or
  *   `cheerio`. `cheerio` being the default.
  *
- * - `validate` is a predicate takin two arguments `statusCode` and
+ * - `validate` is a predicate taking two arguments `statusCode` and
  *   `parsedBody`. If it is false, `LOGIN_FAILED` is thrown, otherwise the
- *   konnector continues.
+ *   signin resolves with `parsedBody` value.
  *
- * - `requestOpts` allows to pass eventual options to the `signin`'s `requestFactory`.
- *   It could be useful for pages using `latin1` `encoding` for instance.
+ * - `requestOpts` allows to pass eventual options to the `signin`'s
+ *   `requestFactory`. It could be useful for pages using `latin1` `encoding`
+ *   for instance.
  *
  * @module signin
  */

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -51,8 +51,8 @@ module.exports = function signin (
   formData,
   parseStrategy = 'cheerio',
   validate = defaultValidate,
-  opts = {}) {
-
+  opts = {})
+{
   const defaultOpts = { jar: true, cheerio: true, json: false }
 
   const rq = requestFactory({
@@ -63,22 +63,22 @@ module.exports = function signin (
   const parseBody = getStrategy(parseStrategy)
 
   return rq(pageUrl)
-  .catch(handleRequestErrors)
-  .then($ => {
-    const [action, inputs] = parseForm($, formSelector)
-    for (let name in formData) {
-      inputs[name] = formData[name]
-    }
+    .catch(handleRequestErrors)
+    .then($ => {
+      const [action, inputs] = parseForm($, formSelector)
+      for (let name in formData) {
+        inputs[name] = formData[name]
+      }
 
-    return submitForm(rq, url.resolve(pageUrl, action), inputs, parseBody)
-  })
-  .then(([statusCode, parsedBody]) => {
-    if (!validate(statusCode, parsedBody)) {
-      throw new Error(errors.LOGIN_FAILED)
-    } else {
-      return Promise.resolve(parsedBody)
-    }
-  })
+      return submitForm(rq, url.resolve(pageUrl, action), inputs, parseBody)
+    })
+    .then(([statusCode, parsedBody]) => {
+      if (!validate(statusCode, parsedBody)) {
+        throw new Error(errors.LOGIN_FAILED)
+      } else {
+        return Promise.resolve(parsedBody)
+      }
+    })
 }
 
 function defaultValidate (statusCode, body) {
@@ -106,12 +106,12 @@ function parseForm ($, formSelector) {
   const action = form.attr('action')
 
   if (!form.is('form')) {
-    const err = 'element matching `'+formSelector+'` is not a `form`'
+    const err = 'element matching `' + formSelector + '` is not a `form`'
     log('error', err)
     throw new Error('INVALID_FORM')
   }
   if (action === undefined) {
-    const err = 'form matching `'+formSelector+'` has no `action` attribute'
+    const err = 'form matching `' + formSelector + '` has no `action` attribute'
     log('error', err)
     throw new Error('INVALID_FORM')
   }
@@ -133,7 +133,7 @@ function submitForm (rq, uri, inputs, parseBody) {
     },
     transform: (body, response) => [response.statusCode, parseBody(body)]
   })
-  .catch(handleRequestErrors)
+    .catch(handleRequestErrors)
 }
 
 function handleRequestErrors (err) {

--- a/packages/cozy-konnector-libs/libs/signin.js
+++ b/packages/cozy-konnector-libs/libs/signin.js
@@ -137,7 +137,7 @@ function submitForm (rq, uri, inputs, parseBody) {
 }
 
 function handleRequestErrors (err) {
-  if (err instanceof rerrors.RequestError) {
+  if (err instanceof rerrors.RequestError || err instanceof rerrors.StatusCodeError) {
     log('error', err)
     throw errors.VENDOR_DOWN
   } else {

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -33,7 +33,21 @@ describe('signin', () => {
     })
   })
 
+  describe('url', () => {
+    it('throws if missing', () => {
+      return expect(() => {
+        signin({formSelector: '#login', parse: 'raw'})
+      }).toThrow(/must be defined/)
+    })
+  })
+
   describe('formSelector', () => {
+    it('throws if missing', () => {
+      return expect(() => {
+        signin({url, parse: 'raw'})
+      }).toThrow(/must be defined/)
+    })
+
     it('throws when matching something else than a form', () => {
       return expect(signin({url, formSelector: '#im-no-form', parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -1,0 +1,126 @@
+const signin = require('./signin')
+const cheerio = require('cheerio')
+
+const logger = require('cozy-logger')
+logger.setLevel('critical')
+
+jest.mock('./request')
+const requestFactory = require('./request')
+
+const form = `
+  <span id="im-no-form" />
+  <form id="got-no-action"></form>
+  <form id="login" action="authenticate">
+    <input name="username" type="text" />
+    <input name="password" type="password" />
+    <input type="submit" />
+  </form>`
+const resp = '<p>Successfull login</p>'
+
+beforeEach(() => {
+  const request = jest.fn()
+  request.mockResolvedValueOnce(cheerio.load(form))
+  request.mockResolvedValueOnce([200, resp])
+  requestFactory.mockReturnValue(request)
+})
+
+const url = 'https://espace-client.lanef.com/templates/logon/logon.cfm'
+describe('signin', () => {
+  describe('happy path', () => {
+    it('works', () => {
+      return expect(signin(url, '#login', {}, 'raw'))
+        .resolves.toEqual(resp)
+    })
+  })
+
+  describe('formSelector', () => {
+    it('throws when matching something else than a form', () => {
+      return expect(signin(url, '#im-no-form', {}, 'raw'))
+        .rejects.toThrow('INVALID_FORM')
+    })
+
+    it('throws when matching a form without action', () => {
+      return expect(signin(url, '#got-no-action', {}, 'raw'))
+        .rejects.toThrow('INVALID_FORM')
+    })
+
+    it('throws when matching no element', () => {
+      return expect(signin(url, '#no-match', {}, 'raw'))
+        .rejects.toThrow('INVALID_FORM')
+    })
+
+    it('continues execution when matched form has action attribute', () => {
+      return expect(signin(url, '#login', {}, 'raw'))
+        .resolves.toEqual(resp)
+    })
+  })
+
+  describe('validate function', () => {
+    const alwaysInvalid = () => false
+    const alwaysValid = () => true
+
+    it('throws LOGIN_FAILED when invalidates', () => {
+      return expect(signin(url, '#login', {}, 'raw', alwaysInvalid))
+        .rejects.toThrow('LOGIN_FAILED')
+    })
+
+    it('continues execution when validates', () => {
+      return expect(signin(url, '#login', {}, 'raw', alwaysValid))
+        .resolves.toEqual(resp)
+    })
+  })
+
+  describe('parsing strategy', () => {
+    it('throws UNKNOWN_PARSING_STRATEGY when unknown', () => {
+      expect(() => signin(url, '#login', {}, 'unknown'))
+        .toThrow('UNKNOWN_PARSING_STRATEGY')
+    })
+
+    describe('is one of the valid ones', () => {
+      for (let strategy of ['raw', 'cheerio', 'json']) {
+        it(`resolves when '${strategy}'`, () => {
+          return expect(signin(url, '#login', {}, strategy))
+            .resolves.toEqual(resp)
+          // As request is mocked, resolution is always the same
+        })
+      }
+    })
+  })
+
+  describe('connection failure', () => {
+    const errors = require('request-promise/errors');
+
+    describe('at first request', () => {
+      beforeEach(() => {
+        const request = jest.fn()
+        request.mockResolvedValueOnce(new Promise(() => {
+            throw new errors.RequestError()
+          })
+        )
+        requestFactory.mockReturnValue(request)
+      })
+
+      it('throws a VENDOR_DOWN error', () => {
+        return expect(signin(url, '#login', {}, 'raw'))
+          .rejects.toThrow('VENDOR_DOWN')
+      })
+    })
+
+    describe('at second request', () => {
+      beforeEach(() => {
+        const request = jest.fn()
+        request.mockResolvedValueOnce(cheerio.load(form))
+        request.mockResolvedValueOnce(new Promise(() => {
+            throw new errors.RequestError()
+          })
+        )
+        requestFactory.mockReturnValue(request)
+      })
+
+      it('throws a VENDOR_DOWN error', () => {
+        return expect(signin(url, '#login', {}, 'raw'))
+          .rejects.toThrow('VENDOR_DOWN')
+      })
+    })
+  })
+})

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -15,7 +15,7 @@ const form = `
     <input name="password" type="password" />
     <input type="submit" />
   </form>`
-const resp = '<p>Successfull login</p>'
+const resp = '<p>Successful login</p>'
 
 beforeEach(() => {
   const request = jest.fn()

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -28,29 +28,29 @@ const url = 'https://espace-client.lanef.com/templates/logon/logon.cfm'
 describe('signin', () => {
   describe('happy path', () => {
     it('works', () => {
-      return expect(signin(url, '#login', {}, 'raw'))
+      return expect(signin(url, '#login', {}, {parse: 'raw'}))
         .resolves.toEqual(resp)
     })
   })
 
   describe('formSelector', () => {
     it('throws when matching something else than a form', () => {
-      return expect(signin(url, '#im-no-form', {}, 'raw'))
+      return expect(signin(url, '#im-no-form', {}, {parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('throws when matching a form without action', () => {
-      return expect(signin(url, '#got-no-action', {}, 'raw'))
+      return expect(signin(url, '#got-no-action', {}, {parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('throws when matching no element', () => {
-      return expect(signin(url, '#no-match', {}, 'raw'))
+      return expect(signin(url, '#no-match', {}, {parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('continues execution when matched form has action attribute', () => {
-      return expect(signin(url, '#login', {}, 'raw'))
+      return expect(signin(url, '#login', {}, {parse: 'raw'}))
         .resolves.toEqual(resp)
     })
   })
@@ -60,26 +60,26 @@ describe('signin', () => {
     const alwaysValid = () => true
 
     it('throws LOGIN_FAILED when invalidates', () => {
-      return expect(signin(url, '#login', {}, 'raw', alwaysInvalid))
+      return expect(signin(url, '#login', {}, {parse: 'raw', validate: alwaysInvalid}))
         .rejects.toThrow('LOGIN_FAILED')
     })
 
     it('continues execution when validates', () => {
-      return expect(signin(url, '#login', {}, 'raw', alwaysValid))
+      return expect(signin(url, '#login', {}, {parse: 'raw', validate: alwaysValid}))
         .resolves.toEqual(resp)
     })
   })
 
   describe('parsing strategy', () => {
     it('throws UNKNOWN_PARSING_STRATEGY when unknown', () => {
-      expect(() => signin(url, '#login', {}, 'unknown'))
+      expect(() => signin(url, '#login', {}, {parse: 'unknown'}))
         .toThrow('UNKNOWN_PARSING_STRATEGY')
     })
 
     describe('is one of the valid ones', () => {
       for (let strategy of ['raw', 'cheerio', 'json']) {
         it(`resolves when '${strategy}'`, () => {
-          return expect(signin(url, '#login', {}, strategy))
+          return expect(signin(url, '#login', {}, {parse: strategy}))
             .resolves.toEqual(resp)
           // As request is mocked, resolution is always the same
         })
@@ -102,7 +102,7 @@ describe('signin', () => {
           })
 
           it('rethrows a VENDOR_DOWN error', () => {
-            return expect(signin(url, '#login', {}, 'raw'))
+            return expect(signin(url, '#login', {}))
               .rejects.toThrow('VENDOR_DOWN')
           })
         })
@@ -118,7 +118,7 @@ describe('signin', () => {
           })
 
           it('rethrows a VENDOR_DOWN error', () => {
-            return expect(signin(url, '#login', {}, 'raw'))
+            return expect(signin(url, '#login', {}))
               .rejects.toThrow('VENDOR_DOWN')
           })
         })

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -88,7 +88,7 @@ describe('signin', () => {
   })
 
   describe('connection failure', () => {
-    const errors = require('request-promise/errors');
+    const errors = require('request-promise/errors')
 
     for (let RErr of [errors.RequestError, errors.StatusCodeError]) {
       describe('at first request', () => {
@@ -115,8 +115,7 @@ describe('signin', () => {
             request.mockResolvedValueOnce(cheerio.load(form))
             request.mockResolvedValueOnce(new Promise(() => {
               throw new RErr('dumb')
-            })
-            )
+            }))
             requestFactory.mockReturnValue(request)
           })
 

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -90,37 +90,42 @@ describe('signin', () => {
   describe('connection failure', () => {
     const errors = require('request-promise/errors');
 
-    describe('at first request', () => {
-      beforeEach(() => {
-        const request = jest.fn()
-        request.mockResolvedValueOnce(new Promise(() => {
-            throw new errors.RequestError()
+    for (let RErr of [errors.RequestError, errors.StatusCodeError]) {
+      describe('at first request', () => {
+        describe(RErr.name, () => {
+          beforeEach(() => {
+            const request = jest.fn()
+            request.mockReturnValue(new Promise(() => {
+              throw new RErr('dumb')
+            }))
+            requestFactory.mockReturnValue(request)
           })
-        )
-        requestFactory.mockReturnValue(request)
-      })
 
-      it('throws a VENDOR_DOWN error', () => {
-        return expect(signin(url, '#login', {}, 'raw'))
-          .rejects.toThrow('VENDOR_DOWN')
-      })
-    })
-
-    describe('at second request', () => {
-      beforeEach(() => {
-        const request = jest.fn()
-        request.mockResolvedValueOnce(cheerio.load(form))
-        request.mockResolvedValueOnce(new Promise(() => {
-            throw new errors.RequestError()
+          it('rethrows a VENDOR_DOWN error', () => {
+            return expect(signin(url, '#login', {}, 'raw'))
+              .rejects.toThrow('VENDOR_DOWN')
           })
-        )
-        requestFactory.mockReturnValue(request)
+        })
       })
 
-      it('throws a VENDOR_DOWN error', () => {
-        return expect(signin(url, '#login', {}, 'raw'))
-          .rejects.toThrow('VENDOR_DOWN')
+      describe('at second request', () => {
+        describe(RErr.name, () => {
+          beforeEach(() => {
+            const request = jest.fn()
+            request.mockResolvedValueOnce(cheerio.load(form))
+            request.mockResolvedValueOnce(new Promise(() => {
+              throw new RErr('dumb')
+            })
+            )
+            requestFactory.mockReturnValue(request)
+          })
+
+          it('rethrows a VENDOR_DOWN error', () => {
+            return expect(signin(url, '#login', {}, 'raw'))
+              .rejects.toThrow('VENDOR_DOWN')
+          })
+        })
       })
-    })
+    }
   })
 })

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -28,29 +28,29 @@ const url = 'https://espace-client.lanef.com/templates/logon/logon.cfm'
 describe('signin', () => {
   describe('happy path', () => {
     it('works', () => {
-      return expect(signin(url, '#login', {}, {parse: 'raw'}))
+      return expect(signin({url, formSelector: '#login', parse: 'raw'}))
         .resolves.toEqual(resp)
     })
   })
 
   describe('formSelector', () => {
     it('throws when matching something else than a form', () => {
-      return expect(signin(url, '#im-no-form', {}, {parse: 'raw'}))
+      return expect(signin({url, formSelector: '#im-no-form', parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('throws when matching a form without action', () => {
-      return expect(signin(url, '#got-no-action', {}, {parse: 'raw'}))
+      return expect(signin({url, formSelector: '#got-no-action', parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('throws when matching no element', () => {
-      return expect(signin(url, '#no-match', {}, {parse: 'raw'}))
+      return expect(signin({url, formSelector: '#no-match', parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 
     it('continues execution when matched form has action attribute', () => {
-      return expect(signin(url, '#login', {}, {parse: 'raw'}))
+      return expect(signin({url, formSelector: '#login', parse: 'raw'}))
         .resolves.toEqual(resp)
     })
   })
@@ -60,26 +60,26 @@ describe('signin', () => {
     const alwaysValid = () => true
 
     it('throws LOGIN_FAILED when invalidates', () => {
-      return expect(signin(url, '#login', {}, {parse: 'raw', validate: alwaysInvalid}))
+      return expect(signin({url, formSelector: '#login', parse: 'raw', validate: alwaysInvalid}))
         .rejects.toThrow('LOGIN_FAILED')
     })
 
     it('continues execution when validates', () => {
-      return expect(signin(url, '#login', {}, {parse: 'raw', validate: alwaysValid}))
+      return expect(signin({url, formSelector: '#login', parse: 'raw', validate: alwaysValid}))
         .resolves.toEqual(resp)
     })
   })
 
   describe('parsing strategy', () => {
     it('throws UNKNOWN_PARSING_STRATEGY when unknown', () => {
-      expect(() => signin(url, '#login', {}, {parse: 'unknown'}))
+      expect(() => signin({url, formSelector: '#login', parse: 'unknown'}))
         .toThrow('UNKNOWN_PARSING_STRATEGY')
     })
 
     describe('is one of the valid ones', () => {
       for (let strategy of ['raw', 'cheerio', 'json']) {
         it(`resolves when '${strategy}'`, () => {
-          return expect(signin(url, '#login', {}, {parse: strategy}))
+          return expect(signin({url, formSelector: '#login', parse: strategy}))
             .resolves.toEqual(resp)
           // As request is mocked, resolution is always the same
         })
@@ -102,7 +102,7 @@ describe('signin', () => {
           })
 
           it('rethrows a VENDOR_DOWN error', () => {
-            return expect(signin(url, '#login', {}))
+            return expect(signin({url, formSelector: '#login'}))
               .rejects.toThrow('VENDOR_DOWN')
           })
         })
@@ -118,7 +118,7 @@ describe('signin', () => {
           })
 
           it('rethrows a VENDOR_DOWN error', () => {
-            return expect(signin(url, '#login', {}))
+            return expect(signin({url, formSelector: '#login'}))
               .rejects.toThrow('VENDOR_DOWN')
           })
         })

--- a/packages/cozy-konnector-libs/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/libs/signin.spec.js
@@ -91,8 +91,8 @@ describe('signin', () => {
     const errors = require('request-promise/errors')
 
     for (let RErr of [errors.RequestError, errors.StatusCodeError]) {
-      describe('at first request', () => {
-        describe(RErr.name, () => {
+      describe(RErr.name, () => {
+        describe('at first request', () => {
           beforeEach(() => {
             const request = jest.fn()
             request.mockReturnValue(new Promise(() => {
@@ -106,10 +106,8 @@ describe('signin', () => {
               .rejects.toThrow('VENDOR_DOWN')
           })
         })
-      })
 
-      describe('at second request', () => {
-        describe(RErr.name, () => {
+        describe('at second request', () => {
           beforeEach(() => {
             const request = jest.fn()
             request.mockResolvedValueOnce(cheerio.load(form))

--- a/packages/cozy-konnector-libs/libs/signon.js
+++ b/packages/cozy-konnector-libs/libs/signon.js
@@ -1,0 +1,114 @@
+/**
+ * The goal of this function is to provide an handy method to log the user in,
+ * on html form pages. On success, it resolves a promise with a parsed body. On
+ * failure, it throws a `LOGIN_FAILED` error.
+ *
+ * It does not submit values provided through `select` tags, except if populated
+ * by user with `population`.
+ * Limit between `baseUrl` and `page` is important. The form `action` will be
+ * concatenated the same way `page` is, to constitute the submission url. For
+ * now, a form with an absolute `action` is not comptabile with this function.
+ *
+ * - `baseUrl` is the root of the url
+ *
+ * - `page` is concatenate (adding a `/`) to `baseUrl` to access the html form
+ *
+ * - `formSelector` is used by cheerio to uniquely identify the form in which to
+ *   log in
+ *
+ * - `population` is an object of { name: value, … }. It is used to populate the
+ *   form, in the proper inputs with the same name as the properties of this
+ *   object, before submitting it.
+ *
+ * - `parseStrategy` allow the user to resolve `signon` with a preparsed body.
+ *   The choice of the strategy for the parsing is one of : `raw`, `json` or
+ *   `cheerio`. `cheerio` being the default.
+ *
+ * - `validate` is a predicate takin two arguments `statusCode` and
+ *   `parsedBody`. If it is false, `LOGIN_FAILED` is thrown, otherwise the
+ *   konnector continues.
+ *
+ * - `opts` allows to pass eventual options to the `signon`'s `requestFactory`.
+ *   It could be useful for pages using `latin1` `encoding` for instance.
+ *
+ * @module signon
+ */
+const errors = require('../helpers/errors')
+const log = require('cozy-logger').namespace('cozy-konnector-libs')
+const requestFactory = require('./request')
+
+module.exports = function signon (
+  baseUrl,
+  page,
+  formSelector,
+  population,
+  parseStrategy = 'cheerio',
+  validate = defaultValidate,
+  opts = {}) {
+
+  const defaultOpts = { jar: true, cheerio: true, json: false }
+
+  const rq = requestFactory({
+    ...opts,
+    ...defaultOpts
+  })
+
+  const parseBody = defineStrategy(parseStrategy)
+
+  return rq(`${baseUrl}/${page}`)
+  .then($ => {
+    const [action, inputs] = parseForm($, formSelector)
+    for (let name in population) {
+      inputs[name] = population[name]
+    }
+
+    return submitForm(rq, `${baseUrl}/${action}`, inputs, parseBody)
+  })
+  .then(([statusCode, parsedBody]) => {
+    if (!validate(statusCode, parsedBody)) {
+      throw new Error(errors.LOGIN_FAILED)
+    } else {
+      return Promise.resolve(parsedBody)
+    }
+  })
+}
+
+function defaultValidate (statusCode, body) {
+  return statusCode === 200
+}
+
+function defineStrategy (parseStrategy) {
+  switch (parseStrategy) {
+    case 'cheerio':
+      return require('cheerio').load
+    case 'json':
+      return JSON.parse
+    default:
+      let err = `connection: parsing strategy ${parseStrategy} unknown. `
+      let fallback = 'Falling back to `raw`. Use one of `raw`, `cheerio` or `json`'
+      log('warn', err + fallback)
+    case 'raw':
+      return (body) => body
+  }
+}
+
+function parseForm ($, formSelector) {
+  const action = $(formSelector).attr('action')
+  const inputs = {}
+  const arr = $(formSelector).serializeArray()
+  for (let input of arr) {
+    inputs[input.name] = input.value
+  }
+  return [action, inputs]
+}
+
+function submitForm (rq, uri, inputs, parseBody) {
+  return rq({
+    uri: uri,
+    method: 'POST',
+    form: {
+      ...inputs
+    },
+    transform: (body, response) => [response.statusCode, parseBody(body)]
+  })
+}


### PR DESCRIPTION
The [carrieje/cozy-konnector-connection](https://github.com/carrieje/cozy-konnector-connection) seems to fit [@laedit](https://forum.cozy.io/t/nouveau-module-konnector-connection/5517/7) [expectations](https://github.com/laedit/cozy-konnector-theoldreader/blob/master/index.ts#L33-L36).
I have used it in three connectors successfully.

@doubleface spoke about [integrating it to the libs](https://forum.cozy.io/t/nouveau-module-konnector-connection/5517/3).
Here is my PR for this to be done.

I have not written tests, as ( #137 ) I am not able to do it using `replay`.
I have not yet tested my contribution manually either, as ( #136 ) I would wait for standalone to work again.

I can at least wait for #136 to be resolved, and test it manually before you take a look.

I have made the choice to name it `signon` as I expect people to integrate it to their `login` function.
And I did not want to reserve the `login` name.
This choice is debatable.