### PR TITLE
Fix standalone command

### DIFF
--- a/packages/cozy-jobs-cli/src/standalone.js
+++ b/packages/cozy-jobs-cli/src/standalone.js
@@ -14,7 +14,7 @@ process.env.COZY_FIELDS = JSON.stringify({
   folder_to_save: '.'
 })
 
-const config = require('cozy-konnector-libs/helpers/init-konnector-config')()
+const config = require('./init-konnector-config')()
 process.env.COZY_URL = config.COZY_URL
 
 const filename = program.args[0] || process.env.npm_package_main || 'index.js'

--- a/packages/cozy-konnector-libs/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/helpers/cozy-client-js-stub.js
@@ -54,7 +54,8 @@ module.exports = {
       // exeption for "io.cozy.accounts" doctype where we return konnector-dev-config.json content
       let result = null
       if (doctype === 'io.cozy.accounts') {
-        const config = require('./init-konnector-config')()
+        const configPath = path.resolve('konnector-dev-config.json')
+        const config = require(configPath)
         result = {auth: config.fields}
       } else {
         return Promise.reject(new Error('find is not implemented yet in cozy-client-js stub'))


### PR DESCRIPTION
The cozy-client-js stub should not care about creating the konnector-dev-config.json.
It should just read it. This is what this PR fixes. Along with the wrong require.
My bad :/

Fixes #136