### PR TITLE
🐝 fix: do not try to link uncategorized operations

### DIFF
--- a/packages/cozy-konnector-libs/libs/linker/billsToOperation/operationsFilters.js
+++ b/packages/cozy-konnector-libs/libs/linker/billsToOperation/operationsFilters.js
@@ -58,12 +58,16 @@ const filterByAmounts = ({ minAmount, maxAmount }) => {
   return amountFilter
 }
 
-const filterByCategory = bill => {
+const filterByCategory = (bill, options={}) => {
   const isHealth = isHealthBill(bill)
   const categoryFilter = operation => {
+    if (options.allowUncategorized !== false
+      && isUncategorizedOperation(operation)) {
+      return true
+    }
     return isHealth
-      ? isHealthOperation(operation) || isUncategorizedOperation(operation)
-      : !isHealthOperation(operation) || isUncategorizedOperation(operation)
+      ? isHealthOperation(operation)
+      : !isHealthOperation(operation)
   }
   return categoryFilter
 }
@@ -95,7 +99,7 @@ const operationsFilters = (bill, operations, options) => {
 
   const fByDates = filterByDates(getDateRangeFromBill(bill, options))
   const fByAmounts = filterByAmounts(getAmountRangeFromBill(bill, options))
-  const fByCategory = filterByCategory(bill)
+  const fByCategory = filterByCategory(bill, options)
   const fByReimbursements = filterByReimbursements(bill, options)
 
   const conditions = [fByDates, fByAmounts, fByCategory]


### PR DESCRIPTION
Problem

When matching health operations, we match also when the operation is uncategorized, which
leads to many false positives.

Solution

Do not match uncategorized operations. I added an option to match on them in case we need
it, but I hope we won't have to use it.