### PR TITLE
cozy-logger should be renamed to cozy-jobs-logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 packages/*/node_modules/*
+yarn-error.log


### PR DESCRIPTION
 to be more cohérent with cozy-jobs-cli and since it can be used by jobs in general