### PR TITLE
🔧 chore: automerge for minor version

### DIFF
--- a/packages/renovate-config-cozy-konnector/package.json
+++ b/packages/renovate-config-cozy-konnector/package.json
@@ -8,7 +8,7 @@
       "extends": [
         "config:base"
       ],
-      "patch": {
+      "minor": {
         "automerge": true
       }
     }


### PR DESCRIPTION
Enables automerging of Renovate PRs when they concern minor version updates.